### PR TITLE
Replace config file with command line switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,55 +130,48 @@ direnv allow
 
 ### Launching the Orchestrator via CLI
 
+You can now run the coding assistant using the `run.fish` script, which simplifies the process of configuring and launching the agent.
+
 #### Run an Orchestrator Task:
 ```bash
-uv run coding-assistant --task "Refactor all function names to snake_case."
+./run.fish --task "Refactor all function names to snake_case."
 ```
 
 #### Print all available MCP tools:
 ```bash
-uv run coding-assistant --print-mcp-tools
+./run.fish --print-mcp-tools
 ```
 
-#### Disable feedback agent:
+#### Example with all arguments:
 ```bash
-uv run coding-assistant --task "Update documentation" --disable-feedback-agent
-```
-
-#### Disable sandboxing (for development):
-```bash
-uv run coding-assistant --task "Debug issue" --disable-sandbox
+./run.fish \
+    --model "gemini/gemini-2.5-flash" \
+    --expert-model "gemini/gemini-2.5-pro" \
+    --disable-feedback-agent \
+    --disable-user-feedback \
+    --instructions "Be concise." \
+    --sandbox-directories /tmp /mnt/wsl \
+    --task "Update the README.md"
 ```
 
 ---
 
 ## Configuration
 
-### User Configuration File
+Configuration is now handled via command-line arguments, providing a more flexible and straightforward way to run the agent. The `run.fish` script provides a convenient way to pass these arguments.
 
-The system automatically creates a configuration file at `~/.config/coding_assistant/config.json` with the following structure:
+### Command-Line Arguments
 
-```json
-{
-  "model": "gpt-4o",
-  "expert_model": "o3",
-  "disable_feedback_agent": false,
-  "disable_user_feedback": false,
-  "instructions": null,
-  "sandbox_directories": [
-    "/tmp"
-  ]
-}
-```
-
-### Configuration Options
-
-- **model**: Default LLM model for general agents
-- **expert_model**: LLM model for complex tasks requiring expert-level reasoning
-- **disable_feedback_agent**: Skip automatic feedback validation
-- **disable_user_feedback**: Skip user feedback prompts
-- **instructions**: Custom instructions to append to all agents
-- **sandbox_directories**: Additional directories to allow in sandbox mode
+-   `--model`: The language model to use for the main agent (default: `gpt-4.1`).
+-   `--expert-model`: The language model to use for the expert agent (default: `o3`).
+-   `--disable-feedback-agent`: Disables the feedback agent.
+-   `--disable-user-feedback`: Disables user feedback prompts.
+-   `--instructions`: Custom instructions for the agent.
+-   `--sandbox-directories`: A list of directories to include in the sandbox (default: `/tmp`).
+-   `--disable-sandbox`: Disables the sandbox entirely.
+-   `--mcp-servers`: A list of MCP server configurations as JSON strings.
+-   `--print-mcp-tools`: Print all available tools from MCP servers.
+-   `--task`: The task for the orchestrator agent.
 
 ### Environment Variables
 
@@ -262,20 +255,21 @@ Specialized agent for:
 
 ## MCP Server Integration
 
-The system automatically initializes MCP servers based on available tools and API keys:
+The system initializes MCP servers based on the `--mcp-servers` command-line argument. The `run.fish` script provides a default configuration for the `filesystem` and `fetch` servers.
 
-### Filesystem Server
-- **Command**: `npx @modelcontextprotocol/server-filesystem <working_directory>`
-- **Purpose**: File system operations and management
+### Default MCP Servers in `run.fish`
 
-### Fetch Server
-- **Command**: `uvx mcp-server-fetch`
-- **Purpose**: Web content fetching and HTTP requests
-
-### Tavily Server (Optional)
-- **Command**: `npx tavily-mcp@0.2.1`
-- **Purpose**: Advanced web search and research
-- **Requirement**: `TAVILY_API_KEY` environment variable
+-   **Filesystem Server**:
+    -   **Name**: `filesystem`
+    -   **Command**: `npx -y @modelcontextprotocol/server-filesystem {working_directory}`
+    -   **Purpose**: File system operations and management.
+-   **Fetch Server**:
+    -   **Name**: `fetch`
+    -   **Command**: `uvx mcp-server-fetch`
+    -   **Purpose**: Web content fetching and HTTP requests.
+-   **Tavily Server (Optional)**:
+    -   To enable the Tavily server, you would add its configuration to the `$mcp_servers` variable in `run.fish`.
+    -   **Requirement**: `TAVILY_API_KEY` environment variable.
 
 ---
 

--- a/run.fish
+++ b/run.fish
@@ -1,16 +1,10 @@
 #!/usr/bin/env fish
 
-set sandbox_dirs \
-    /tmp \
-    /mnt/wsl
-
-set mcp_servers \
-    '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"]}' \
-    '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}'
-
 uv --project (dirname (status filename)) run coding-assistant \
     --model "gemini/gemini-2.5-flash" \
     --expert-model "gemini/gemini-2.5-pro" \
-    --sandbox-directories $sandbox_dirs \
-    --mcp-servers $mcp_servers \
+    --sandbox-directories /tmp /mnt/wsl \
+    --mcp-servers \
+        '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"]}' \
+        '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}' \
     $argv

--- a/run.fish
+++ b/run.fish
@@ -1,0 +1,16 @@
+#!/usr/bin/env fish
+
+set sandbox_dirs \
+    /tmp \
+    /mnt/wsl
+
+set mcp_servers \
+    '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"], "env": []}' \
+    '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"], "env": []}'
+
+uv --project (dirname (status filename)) run coding-assistant \
+    --model "gemini/gemini-2.5-flash" \
+    --expert-model "gemini/gemini-2.5-pro" \
+    --sandbox-directories $sandbox_dirs \
+    --mcp-servers $mcp_servers \
+    $argv

--- a/run.fish
+++ b/run.fish
@@ -5,8 +5,8 @@ set sandbox_dirs \
     /mnt/wsl
 
 set mcp_servers \
-    '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"], "env": []}' \
-    '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"], "env": []}'
+    '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"]}' \
+    '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}'
 
 uv --project (dirname (status filename)) run coding-assistant \
     --model "gemini/gemini-2.5-flash" \

--- a/src/coding_assistant/agents/agents.py
+++ b/src/coding_assistant/agents/agents.py
@@ -222,10 +222,10 @@ class ExecuteShellCommandTool(Tool):
     def description(self) -> str:
         return (
             "Execute a shell command and return the output. The command will be executed in bash. Examples for commands are:\n"
-            "- `exa` for listing files in a directory\n"
+            "- `eza` or `ls` for listing files in a directory\n"
             "- `git` for running git commands\n"
-            "- `fd` for searching files\n"
-            "- `rg` for searching text in files\n"
+            "- `fd` or `find` for searching files\n"
+            "- `rg` or `grep` for searching text in files\n"
             "- `gh` for interfacing with GitHub\n"
         )
 

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -4,16 +4,22 @@ from typing import List
 
 
 @dataclass
+class MCPServerConfig:
+    """Configuration for an MCP server."""
+    name: str
+    command: str
+    args: List[str] = field(default_factory=list)
+    env: List[str] = field(default_factory=list)  # List of env var keys to pass through
+
+
+@dataclass
 class Config:
-    model: str = "gpt-4.1"
-    expert_model: str = "o3"
-    disable_feedback_agent: bool = False
-    disable_user_feedback: bool = False
-    instructions: str | None = None
-    sandbox_directories: List[Path] = field(
-        default_factory=lambda: [
-            Path("/tmp"),
-        ]
-    )
+    model: str
+    expert_model: str
+    disable_feedback_agent: bool
+    disable_user_feedback: bool
+    instructions: str | None
+    sandbox_directories: List[Path]
+    mcp_servers: List[MCPServerConfig]
     
 

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -1,16 +1,8 @@
-import json
-import logging
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, List
-
-from dataclasses_json import dataclass_json
-
-logger = logging.getLogger(__name__)
+from typing import List
 
 
-@dataclass_json
 @dataclass
 class Config:
     model: str = "gpt-4.1"
@@ -20,44 +12,8 @@ class Config:
     instructions: str | None = None
     sandbox_directories: List[Path] = field(
         default_factory=lambda: [
-            "/tmp",
+            Path("/tmp"),
         ]
     )
+    
 
-
-def get_config_dir() -> Path:
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
-    config_dir = Path(xdg_config_home) / "coding_assistant"
-    config_dir.mkdir(parents=True, exist_ok=True)
-    return config_dir
-
-
-def _get_config_file_path() -> Path:
-    return get_config_dir() / "config.json"
-
-
-def _create_default_config_file_if_not_exists(config_path: Path):
-    if config_path.exists():
-        return
-
-    logger.info(f"Creating default configuration file at {config_path}")
-
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(Config().to_json(indent=2))
-
-
-def load_user_config() -> Config:
-    config_path = _get_config_file_path()
-    _create_default_config_file_if_not_exists(config_path)
-    config = Config.from_json(config_path.read_text())
-
-    # Convert directory strings to Path objects
-    for i, directory in enumerate(config.sandbox_directories):
-        if isinstance(directory, str):
-            config.sandbox_directories[i] = Path(directory)
-
-    # Expand user directories
-    for i, directory in enumerate(config.sandbox_directories):
-        config.sandbox_directories[i] = config.sandbox_directories[i].expanduser()
-
-    return config

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pathlib import Path
 
 import requests
@@ -18,10 +18,10 @@ from rich.table import Table
 from coding_assistant.agents.agents import OrchestratorTool
 from coding_assistant.agents.logic import run_agent_loop
 from coding_assistant.cache import get_cache_dir, get_conversation_history, save_conversation_history
-from coding_assistant.config import Config
+from coding_assistant.config import Config, MCPServerConfig
 from coding_assistant.instructions import get_instructions
 from coding_assistant.sandbox import sandbox
-from coding_assistant.tools import Tools, get_all_mcp_servers
+from coding_assistant.tools import Tools, get_mcp_servers_from_config
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -31,45 +31,64 @@ logger.setLevel(logging.INFO)
 
 
 def parse_args():
-    parser = ArgumentParser()
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter, description="Coding Assistant CLI")
     parser.add_argument("--task", type=str, help="Task for the orchestrator agent.")
     parser.add_argument("--print-mcp-tools", action="store_true", help="Print all available tools from MCP servers.")
-    
-    # Configuration options (replacing config file)
     parser.add_argument("--model", type=str, default="gpt-4.1", help="Model to use for the orchestrator agent.")
     parser.add_argument("--expert-model", type=str, default="o3", help="Expert model to use.")
     parser.add_argument(
         "--disable-feedback-agent", action="store_true", default=False, help="Disable the feedback agent."
     )
-    parser.add_argument(
-        "--disable-user-feedback", action="store_true", default=False, help="Disable user feedback."
-    )
+    parser.add_argument("--disable-user-feedback", action="store_true", default=False, help="Disable user feedback.")
     parser.add_argument("--instructions", type=str, help="Custom instructions for the agent.")
     parser.add_argument(
-        "--sandbox-directories", 
-        nargs="*", 
-        default=["/tmp"], 
-        help="Additional directories to include in the sandbox (default: /tmp)."
+        "--sandbox-directories",
+        nargs="*",
+        default=["/tmp"],
+        help="Additional directories to include in the sandbox (default: /tmp).",
     )
     parser.add_argument("--disable-sandbox", action="store_true", default=False, help="Disable sandboxing.")
-    
+    parser.add_argument(
+        "--mcp-servers",
+        nargs="*",
+        default=[],
+        help='MCP server configurations as JSON strings. Format: \'{"name": "server_name", "command": "command", "args": ["arg1", "arg2"], "env": ["ENV_VAR1", "ENV_VAR2"]}\'',
+    )
+
     return parser.parse_args()
 
 
 def create_config_from_args(args) -> Config:
     sandbox_dirs = [Path(d) for d in args.sandbox_directories]
-    
+
     # Expand user directories
     for i, directory in enumerate(sandbox_dirs):
         sandbox_dirs[i] = directory.expanduser()
-    
+
+    # Parse MCP server configurations from JSON strings
+    mcp_servers = []
+    for mcp_config_json in args.mcp_servers:
+        try:
+            config_dict = json.loads(mcp_config_json)
+            mcp_server_config = MCPServerConfig(
+                name=config_dict["name"],
+                command=config_dict["command"],
+                args=config_dict.get("args", []),
+                env=config_dict.get("env", []),  # Now expects a list of env var keys
+            )
+            mcp_servers.append(mcp_server_config)
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Invalid MCP server configuration: {mcp_config_json}. Error: {e}")
+            sys.exit(1)
+
     return Config(
         model=args.model,
         expert_model=args.expert_model,
         disable_feedback_agent=args.disable_feedback_agent,
         disable_user_feedback=args.disable_user_feedback,
         instructions=args.instructions,
-        sandbox_directories=sandbox_dirs
+        sandbox_directories=sandbox_dirs,
+        mcp_servers=mcp_servers,
     )
 
 
@@ -156,7 +175,11 @@ async def _main():
     else:
         logger.warning("Sandboxing is disabled")
 
-    async with get_all_mcp_servers(working_directory) as mcp_servers:
+    # Use configured MCP servers
+    mcp_server_configs = config.mcp_servers
+    logger.info(f"Using MCP server configurations: {[s.name for s in mcp_server_configs]}")
+
+    async with get_mcp_servers_from_config(mcp_server_configs, working_directory) as mcp_servers:
         tools = Tools(mcp_servers=mcp_servers)
 
         if args.print_mcp_tools:
@@ -165,19 +188,15 @@ async def _main():
 
         result = None
         with tracer.start_as_current_span("run_root_agent"):
-            if args.task:
-                tool = OrchestratorTool(config, tools)
-                result = await tool.execute(
-                    {
-                        "task": args.task,
-                        "history": conversation_history[-5:],
-                        "instructions": get_instructions(working_directory, config),
-                    }
-                )
-                summary = tool.summary
-            else:
-                print("No task or question specified.")
-                sys.exit(1)
+            tool = OrchestratorTool(config, tools)
+            result = await tool.execute(
+                {
+                    "task": args.task,
+                    "history": conversation_history[-5:],
+                    "instructions": get_instructions(working_directory, config),
+                }
+            )
+            summary = tool.summary
 
         print(f"Finished with: {result}")
         print(f"Summary: {summary}")

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -182,12 +182,10 @@ async def _main():
             await print_mcp_tools(mcp_servers)
             return
 
-        result = None
-        
         if not args.task:
             logger.error("No task provided. Please specify a task to execute.")
             return
-        
+
         with tracer.start_as_current_span("run_root_agent"):
             tool = OrchestratorTool(config, tools)
             result = await tool.execute(

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -68,18 +68,14 @@ def create_config_from_args(args) -> Config:
     # Parse MCP server configurations from JSON strings
     mcp_servers = []
     for mcp_config_json in args.mcp_servers:
-        try:
-            config_dict = json.loads(mcp_config_json)
-            mcp_server_config = MCPServerConfig(
-                name=config_dict["name"],
-                command=config_dict["command"],
-                args=config_dict.get("args", []),
-                env=config_dict.get("env", []),  # Now expects a list of env var keys
-            )
-            mcp_servers.append(mcp_server_config)
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.error(f"Invalid MCP server configuration: {mcp_config_json}. Error: {e}")
-            sys.exit(1)
+        config_dict = json.loads(mcp_config_json)
+        mcp_server_config = MCPServerConfig(
+            name=config_dict["name"],
+            command=config_dict["command"],
+            args=config_dict.get("args", []),
+            env=config_dict.get("env", []),
+        )
+        mcp_servers.append(mcp_server_config)
 
     return Config(
         model=args.model,

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -183,6 +183,11 @@ async def _main():
             return
 
         result = None
+        
+        if not args.task:
+            logger.error("No task provided. Please specify a task to execute.")
+            return
+        
         with tracer.start_as_current_span("run_root_agent"):
             tool = OrchestratorTool(config, tools)
             result = await tool.execute(

--- a/src/coding_assistant/tools.py
+++ b/src/coding_assistant/tools.py
@@ -84,12 +84,9 @@ async def get_mcp_servers_from_config(
                 if env_var in os.environ:
                     env[env_var] = os.environ[env_var]
 
-            try:
-                server = await stack.enter_async_context(
-                    _get_mcp_server(name=server_config.name, command=server_config.command, args=args, env=env)
-                )
-                servers.append(server)
-            except Exception as e:
-                logger.warning(f"Failed to start MCP server '{server_config.name}': {e}")
+            server = await stack.enter_async_context(
+                _get_mcp_server(name=server_config.name, command=server_config.command, args=args, env=env)
+            )
+            servers.append(server)
 
         yield servers

--- a/src/coding_assistant/tools.py
+++ b/src/coding_assistant/tools.py
@@ -81,8 +81,9 @@ async def get_mcp_servers_from_config(
 
             # Add environment variables specified in server config
             for env_var in server_config.env:
-                if env_var in os.environ:
-                    env[env_var] = os.environ[env_var]
+                if env_var not in os.environ:
+                    raise ValueError(f"Required environment variable '{env_var}' for MCP server '{server_config.name}' is not set")
+                env[env_var] = os.environ[env_var]
 
             server = await stack.enter_async_context(
                 _get_mcp_server(name=server_config.name, command=server_config.command, args=args, env=env)


### PR DESCRIPTION
This PR replaces the existing file-based configuration with command-line arguments, enabling dynamic setup of MCP servers and easing user customization.

- Moves all configuration options (model choice, sandbox dirs, MCP servers, etc.) to CLI flags and drops the JSON config file.
- Introduces `get_mcp_servers_from_config` to spin up servers from `MCPServerConfig` objects parsed from JSON strings.
- Updates the `run.fish` script and README to demonstrate the new CLI-driven workflow.