### PR TITLE
feat: Trigger conversation shortening based on token count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 [tool.black]
 line-length = 120
 
+[tool.ruff]
+line-length = 120
+
 [project.scripts]
 coding-assistant = "coding_assistant.main:main"
 

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -160,9 +160,13 @@ async def do_single_step(agent: Agent, agent_callbacks: AgentCallbacks, shorten_
             "I detected a step from you without any tool calls. This is not allowed. If you want to ask the client something, please use the `ask_user` tool. If you are done with your task, please call the `finish_task` tool to signal that you are done. Otherwise, continue your work.",
         )
 
-    # Note: We removed the token-based shortening prompt since conversation shortening
-    # is now handled immediately when the shorten_conversation tool is called.
-    # The agent can be instructed to call shorten_conversation through other means.
+    if completion.tokens > shorten_conversation_at_tokens:
+        append_user_message(
+            agent.history,
+            agent_callbacks,
+            agent.name,
+            "Your conversation history has grown too large. Please summarize it by using the `shorten_conversation` tool.",
+        )
 
     return message
 
@@ -171,7 +175,7 @@ async def do_single_step(agent: Agent, agent_callbacks: AgentCallbacks, shorten_
 async def run_agent_loop(
     agent: Agent,
     agent_callbacks: AgentCallbacks,
-    shorten_conversation_at_tokens=100_000,
+    shorten_conversation_at_tokens=200_000,
 ) -> AgentOutput:
     if agent.output:
         raise RuntimeError("Agent already has a result or summary.")

--- a/src/coding_assistant/agents/history.py
+++ b/src/coding_assistant/agents/history.py
@@ -10,7 +10,9 @@ def append_tool_message(
     function_args: dict,
     function_call_result: str,
 ):
-    callbacks.on_tool_message(agent_name, function_name, function_args, function_call_result)
+    callbacks.on_tool_message(
+        agent_name, function_name, function_args, function_call_result
+    )
 
     history.append(
         {
@@ -22,7 +24,9 @@ def append_tool_message(
     )
 
 
-def append_user_message(history: list, callbacks: AgentCallbacks, agent_name: str, content: str):
+def append_user_message(
+    history: list, callbacks: AgentCallbacks, agent_name: str, content: str
+):
     callbacks.on_user_message(agent_name, content)
 
     history.append(
@@ -33,7 +37,9 @@ def append_user_message(history: list, callbacks: AgentCallbacks, agent_name: st
     )
 
 
-def append_assistant_message(history: list, callbacks: AgentCallbacks, agent_name: str, message):
+def append_assistant_message(
+    history: list, callbacks: AgentCallbacks, agent_name: str, message
+):
     if message.content:
         callbacks.on_assistant_message(agent_name, message.content)
 

--- a/src/coding_assistant/agents/tests/test_agents.py
+++ b/src/coding_assistant/agents/tests/test_agents.py
@@ -20,6 +20,7 @@ def create_test_config() -> Config:
         instructions=None,
         sandbox_directories=[],
         mcp_servers=[],
+        shorten_conversation_at_tokens=200_000,
     )
 
 

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -21,5 +21,6 @@ class Config:
     instructions: str | None
     sandbox_directories: List[Path]
     mcp_servers: List[MCPServerConfig]
+    shorten_conversation_at_tokens: int
 
 

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -94,6 +94,12 @@ def parse_args():
         default="http://localhost:4318/v1/traces",
         help="Endpoint for OTLP trace exporter.",
     )
+    parser.add_argument(
+        "--shorten-conversation-at-tokens",
+        type=int,
+        default=200_000,
+        help="Number of tokens after which conversation should be shortened.",
+    )
 
     return parser.parse_args()
 
@@ -125,6 +131,7 @@ def create_config_from_args(args) -> Config:
         instructions=args.instructions,
         sandbox_directories=sandbox_dirs,
         mcp_servers=mcp_servers,
+        shorten_conversation_at_tokens=args.shorten_conversation_at_tokens,
     )
 
 


### PR DESCRIPTION
This commit introduces a mechanism to automatically shorten the conversation history when the number of tokens exceeds a configurable threshold.

Key changes:
- Added  to the configuration.
- The  now monitors the token count and prompts the agent to shorten the conversation history when the limit is reached.
- The default threshold is set to 200,000 tokens.
- Added ruff configuration to pyproject.toml.
