### PR TITLE
Add patterns for shell confirmation

### DIFF
--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -17,3 +17,4 @@ class Config(BaseModel):
     enable_user_feedback: bool
     shorten_conversation_at_tokens: int
     enable_ask_user: bool
+    ask_shell_confirmation_patterns: List[str] = Field(default_factory=list)

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -17,4 +17,4 @@ class Config(BaseModel):
     enable_user_feedback: bool
     shorten_conversation_at_tokens: int
     enable_ask_user: bool
-    ask_shell_confirmation_patterns: List[str] = Field(default_factory=list)
+    shell_confirmation_patterns: List[str] = Field(default_factory=list)

--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -12,7 +12,7 @@ INSTRUCTIONS = """
 - Do not use the 'mcp_filesystem_search_files' tool, use the 'rg' shell command instead.
 - Do not install any software on the users computer before asking.
 - Do not run any binary using `uvx` or `npx` without asking the user first.
-- Almost all of your tasks are related to the codebase you are currently working in. When the user asks a question, be *very* sure before starting a web search that this is what the user wants.
+- When the user asks a question, be *very* sure before starting a web search that this is what the user wants.
 - If you output text, use markdown formatting where appropriate.
 """.strip()
 

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -132,6 +132,13 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--ask-shell-confirmation",
+        nargs="*",
+        default=[],
+        help="Ask for confirmation before executing a shell command that matches any of the given patterns.",
+    )
+
+    parser.add_argument(
         "--wait-for-debugger",
         action=BooleanOptionalAction,
         default=False,
@@ -149,6 +156,7 @@ def create_config_from_args(args) -> Config:
         enable_user_feedback=args.user_feedback,
         shorten_conversation_at_tokens=args.shorten_conversation_at_tokens,
         enable_ask_user=args.ask_user,
+        ask_shell_confirmation_patterns=args.ask_shell_confirmation,
     )
 
 

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -1,7 +1,9 @@
+from unittest.mock import patch
+
 import pytest
+
 from coding_assistant.config import Config
 from coding_assistant.tools.tools import AskClientTool, ExecuteShellCommandTool
-from unittest.mock import patch
 
 
 @pytest.mark.asyncio
@@ -15,46 +17,47 @@ async def test_execute_shell_command_tool_timeout():
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
     mock_ask.return_value = "y"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
-    result = await tool.execute({"command": "rm -rf /"})
-    assert "denied" not in result.content.lower()
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    result = await tool.execute({"command": "echo 'Hello'"})
+    assert result.content == "Hello\n"
 
 
 @pytest.mark.asyncio
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes_with_whitespace(mock_ask):
-    mock_ask.return_value = "y"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
-    result = await tool.execute({"command": "  rm -rf /"})
-    assert "denied" not in result.content.lower()
+    mock_ask.return_value = "n"
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    result = await tool.execute({"command": "  echo 'Hello'"})
+    assert "denied" in result.content.lower()
 
 
 @pytest.mark.asyncio
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_no(mock_ask):
     mock_ask.return_value = "n"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
-    result = await tool.execute({"command": "rm -rf /"})
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    result = await tool.execute({"command": "echo 'Hello'"})
     assert "denied" in result.content.lower()
 
 
 @pytest.mark.asyncio
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_no_match(mock_ask):
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
-    result = await tool.execute({"command": "ls -l"})
-    assert "denied" not in result.content.lower()
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["ls"])
+    result = await tool.execute({"command": "echo 'Hello'"})
+    assert result.content == "Hello\n"
     mock_ask.assert_not_called()
 
 
 @pytest.mark.asyncio
-@patch('rich.prompt.Prompt.ask')
+@patch("rich.prompt.Prompt.ask")
 async def test_ask_client_tool_enabled(mock_ask):
     mock_ask.return_value = "yes"
     tool = AskClientTool(enabled=True)
     result = await tool.execute({"question": "Do you want to proceed?", "default_answer": "no"})
     assert result.content == "yes"
     mock_ask.assert_called_once_with("Do you want to proceed?", default="no")
+
 
 @pytest.mark.asyncio
 async def test_ask_client_tool_disabled():

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -10,6 +10,31 @@ async def test_execute_shell_command_tool_timeout():
     result = await tool.execute({"command": "sleep 2", "timeout": 1})
     assert "timed out" in result.content
 
+
+@pytest.mark.asyncio
+@patch("rich.prompt.Prompt.ask")
+async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
+    mock_ask.return_value = "y"
+    ask_client_tool = AskClientTool(enabled=True)
+    tool = ExecuteShellCommandTool(
+        ask_shell_confirmation_patterns=["rm"], ask_client_tool=ask_client_tool
+    )
+    result = await tool.execute({"command": "rm -rf /"})
+    assert "denied" not in result.content.lower()
+
+
+@pytest.mark.asyncio
+@patch("rich.prompt.Prompt.ask")
+async def test_execute_shell_command_tool_confirmation_no(mock_ask):
+    mock_ask.return_value = "n"
+    ask_client_tool = AskClientTool(enabled=True)
+    tool = ExecuteShellCommandTool(
+        ask_shell_confirmation_patterns=["rm"], ask_client_tool=ask_client_tool
+    )
+    result = await tool.execute({"command": "rm -rf /"})
+    assert "denied" in result.content.lower()
+
+
 @pytest.mark.asyncio
 @patch('rich.prompt.Prompt.ask')
 async def test_ask_client_tool_enabled(mock_ask):

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -17,7 +17,7 @@ async def test_execute_shell_command_tool_timeout():
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
     mock_ask.return_value = "y"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    tool = ExecuteShellCommandTool(shell_confirmation_patterns=["echo"])
     result = await tool.execute({"command": "echo 'Hello'"})
     assert result.content == "Hello\n"
 
@@ -26,7 +26,7 @@ async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes_with_whitespace(mock_ask):
     mock_ask.return_value = "n"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    tool = ExecuteShellCommandTool(shell_confirmation_patterns=["echo"])
     result = await tool.execute({"command": "  echo 'Hello'"})
     assert "denied" in result.content.lower()
 
@@ -35,7 +35,7 @@ async def test_execute_shell_command_tool_confirmation_yes_with_whitespace(mock_
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_no(mock_ask):
     mock_ask.return_value = "n"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["echo"])
+    tool = ExecuteShellCommandTool(shell_confirmation_patterns=["echo"])
     result = await tool.execute({"command": "echo 'Hello'"})
     assert "denied" in result.content.lower()
 
@@ -43,7 +43,7 @@ async def test_execute_shell_command_tool_confirmation_no(mock_ask):
 @pytest.mark.asyncio
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_no_match(mock_ask):
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["ls"])
+    tool = ExecuteShellCommandTool(shell_confirmation_patterns=["ls"])
     result = await tool.execute({"command": "echo 'Hello'"})
     assert result.content == "Hello\n"
     mock_ask.assert_not_called()

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -15,10 +15,7 @@ async def test_execute_shell_command_tool_timeout():
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
     mock_ask.return_value = "y"
-    ask_client_tool = AskClientTool(enabled=True)
-    tool = ExecuteShellCommandTool(
-        ask_shell_confirmation_patterns=["rm"], ask_client_tool=ask_client_tool
-    )
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["rm"])
     result = await tool.execute({"command": "rm -rf /"})
     assert "denied" not in result.content.lower()
 
@@ -27,10 +24,7 @@ async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_no(mock_ask):
     mock_ask.return_value = "n"
-    ask_client_tool = AskClientTool(enabled=True)
-    tool = ExecuteShellCommandTool(
-        ask_shell_confirmation_patterns=["rm"], ask_client_tool=ask_client_tool
-    )
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["rm"])
     result = await tool.execute({"command": "rm -rf /"})
     assert "denied" in result.content.lower()
 

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -15,8 +15,17 @@ async def test_execute_shell_command_tool_timeout():
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
     mock_ask.return_value = "y"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
     result = await tool.execute({"command": "rm -rf /"})
+    assert "denied" not in result.content.lower()
+
+
+@pytest.mark.asyncio
+@patch("rich.prompt.Prompt.ask")
+async def test_execute_shell_command_tool_confirmation_yes_with_whitespace(mock_ask):
+    mock_ask.return_value = "y"
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
+    result = await tool.execute({"command": "  rm -rf /"})
     assert "denied" not in result.content.lower()
 
 
@@ -24,7 +33,7 @@ async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_no(mock_ask):
     mock_ask.return_value = "n"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
     result = await tool.execute({"command": "rm -rf /"})
     assert "denied" in result.content.lower()
 
@@ -32,7 +41,7 @@ async def test_execute_shell_command_tool_confirmation_no(mock_ask):
 @pytest.mark.asyncio
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_no_match(mock_ask):
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"rm"])
     result = await tool.execute({"command": "ls -l"})
     assert "denied" not in result.content.lower()
     mock_ask.assert_not_called()

--- a/src/coding_assistant/tests/test_tools.py
+++ b/src/coding_assistant/tests/test_tools.py
@@ -15,7 +15,7 @@ async def test_execute_shell_command_tool_timeout():
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
     mock_ask.return_value = "y"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["rm"])
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
     result = await tool.execute({"command": "rm -rf /"})
     assert "denied" not in result.content.lower()
 
@@ -24,9 +24,18 @@ async def test_execute_shell_command_tool_confirmation_yes(mock_ask):
 @patch("rich.prompt.Prompt.ask")
 async def test_execute_shell_command_tool_confirmation_no(mock_ask):
     mock_ask.return_value = "n"
-    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=["rm"])
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
     result = await tool.execute({"command": "rm -rf /"})
     assert "denied" in result.content.lower()
+
+
+@pytest.mark.asyncio
+@patch("rich.prompt.Prompt.ask")
+async def test_execute_shell_command_tool_no_match(mock_ask):
+    tool = ExecuteShellCommandTool(ask_shell_confirmation_patterns=[r"^\s*rm"])
+    result = await tool.execute({"command": "ls -l"})
+    assert "denied" not in result.content.lower()
+    mock_ask.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -122,7 +122,7 @@ class OrchestratorTool(AgentToolBase):
             tools=[
                 AgentTool(self._config, self._mcp_servers, self._agent_callbacks),
                 ask_client_tool,
-                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
+                ExecuteShellCommandTool(self._config.shell_confirmation_patterns),
                 FinishTaskTool(),
                 ShortenConversation(),
             ],
@@ -191,7 +191,7 @@ class AgentTool(AgentToolBase):
             ),
             mcp_servers=self._mcp_servers,
             tools=[
-                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
+                ExecuteShellCommandTool(self._config.shell_confirmation_patterns),
                 ask_client_tool,
                 FinishTaskTool(),
                 ShortenConversation(),
@@ -251,9 +251,9 @@ class ExecuteShellCommandSchema(BaseModel):
 class ExecuteShellCommandTool(Tool):
     def __init__(
         self,
-        ask_shell_confirmation_patterns: List[str] = [],
+        shell_confirmation_patterns: List[str] = [],
     ):
-        self._ask_shell_confirmation_patterns = ask_shell_confirmation_patterns
+        self._shell_confirmation_patterns = shell_confirmation_patterns
 
     def name(self) -> str:
         return "execute_shell_command"
@@ -277,9 +277,9 @@ class ExecuteShellCommandTool(Tool):
         command = parameters["command"].strip()
         timeout = parameters.get("timeout", 60)
 
-        for pattern in self._ask_shell_confirmation_patterns:
+        for pattern in self._shell_confirmation_patterns:
             if re.search(pattern, command):
-                question = f"`{command}` matches `{pattern}`. Run? (y/N)"
+                question = f"Run `{command}`? (y/N)"
                 answer = await asyncio.to_thread(Prompt.ask, question)
                 if answer.lower() != "y":
                     return TextResult(content="Command execution denied.")
@@ -342,7 +342,7 @@ class FeedbackTool(AgentToolBase):
             ),
             mcp_servers=self._mcp_servers,
             tools=[
-                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
+                ExecuteShellCommandTool(self._config.shell_confirmation_patterns),
                 FinishTaskTool(),
                 ShortenConversation(),
             ],

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -3,7 +3,7 @@ import logging
 import re
 import subprocess
 import textwrap
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field
 from rich.prompt import Prompt
@@ -122,9 +122,7 @@ class OrchestratorTool(AgentToolBase):
             tools=[
                 AgentTool(self._config, self._mcp_servers, self._agent_callbacks),
                 ask_client_tool,
-                ExecuteShellCommandTool(
-                    self._config.ask_shell_confirmation_patterns
-                ),
+                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
                 FinishTaskTool(),
                 ShortenConversation(),
             ],
@@ -193,9 +191,7 @@ class AgentTool(AgentToolBase):
             ),
             mcp_servers=self._mcp_servers,
             tools=[
-                ExecuteShellCommandTool(
-                    self._config.ask_shell_confirmation_patterns
-                ),
+                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
                 ask_client_tool,
                 FinishTaskTool(),
                 ShortenConversation(),
@@ -278,7 +274,7 @@ class ExecuteShellCommandTool(Tool):
     async def execute(self, parameters: dict) -> TextResult:
         assert "command" in parameters
 
-        command = parameters["command"]
+        command = parameters["command"].strip()
         timeout = parameters.get("timeout", 60)
 
         for pattern in self.ask_shell_confirmation_patterns:
@@ -347,9 +343,7 @@ class FeedbackTool(AgentToolBase):
             ),
             mcp_servers=self._mcp_servers,
             tools=[
-                ExecuteShellCommandTool(
-                    self._config.ask_shell_confirmation_patterns
-                ),
+                ExecuteShellCommandTool(self._config.ask_shell_confirmation_patterns),
                 FinishTaskTool(),
                 ShortenConversation(),
             ],

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 import subprocess
 import textwrap
 from typing import Optional, List
@@ -281,7 +282,7 @@ class ExecuteShellCommandTool(Tool):
         timeout = parameters.get("timeout", 60)
 
         for pattern in self.ask_shell_confirmation_patterns:
-            if pattern in command:
+            if re.search(pattern, command):
                 question = f"Do you want to execute the following command? `{command}`"
                 default_answer = "y/N"
                 answer = await asyncio.to_thread(Prompt.ask, question, default=default_answer)

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -251,9 +251,9 @@ class ExecuteShellCommandSchema(BaseModel):
 class ExecuteShellCommandTool(Tool):
     def __init__(
         self,
-        ask_shell_confirmation_patterns: Optional[List[str]] = None,
+        ask_shell_confirmation_patterns: List[str] = [],
     ):
-        self.ask_shell_confirmation_patterns = ask_shell_confirmation_patterns or []
+        self._ask_shell_confirmation_patterns = ask_shell_confirmation_patterns
 
     def name(self) -> str:
         return "execute_shell_command"
@@ -277,11 +277,10 @@ class ExecuteShellCommandTool(Tool):
         command = parameters["command"].strip()
         timeout = parameters.get("timeout", 60)
 
-        for pattern in self.ask_shell_confirmation_patterns:
+        for pattern in self._ask_shell_confirmation_patterns:
             if re.search(pattern, command):
-                question = f"Do you want to execute the following command? `{command}`"
-                default_answer = "y/N"
-                answer = await asyncio.to_thread(Prompt.ask, question, default=default_answer)
+                question = f"`{command}` matches `{pattern}`. Run? (y/N)"
+                answer = await asyncio.to_thread(Prompt.ask, question)
                 if answer.lower() != "y":
                     return TextResult(content="Command execution denied.")
                 break


### PR DESCRIPTION
- **feat(tools): Modify ExecuteShellCommandTool to accept confirmation patterns**
- **feat(config): Add ask_shell_confirmation_patterns to config and CLI**
- **test(tools): Add test for shell command confirmation**
- **refactor(tools): Use prompt directly in ExecuteShellCommandTool**
- **feat(tools): Use regex for shell command confirmation**
- **feat: improve shell command confirmation**
- **Refactor shell confirmation and improve tests**
- **Refactor: Rename shell confirmation feature**
