### PR TITLE
feat: Move shell command examples to instructions

### DIFF
--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -14,6 +14,12 @@ INSTRUCTIONS = """
 - Do not run any binary using `uvx` or `npx` without asking the user first.
 - When the user asks a question, be *very* sure before starting a web search that this is what the user wants.
 - If you output text, use markdown formatting where appropriate.
+- Use shell commands for common tasks, such as:
+    - `eza` or `ls` for listing files in a directory
+    - `git` for running git commands
+    - `fd` or `find` for searching files
+    - `rg` or `grep` for searching text in files
+    - `gh` for interfacing with GitHub
 """.strip()
 
 PLANNING_INSTRUCTIONS = """

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -251,14 +251,7 @@ class ExecuteShellCommandTool(Tool):
         return "execute_shell_command"
 
     def description(self) -> str:
-        return (
-            "Execute a shell command and return the output. The command will be executed in bash. Examples for commands are:\n"
-            "- `eza` or `ls` for listing files in a directory\n"
-            "- `git` for running git commands\n"
-            "- `fd` or `find` for searching files\n"
-            "- `rg` or `grep` for searching text in files\n"
-            "- `gh` for interfacing with GitHub\n"
-        )
+        return "Execute a shell command and return the output. The command will be executed in bash."
 
     def parameters(self) -> dict:
         return ExecuteShellCommandSchema.model_json_schema()


### PR DESCRIPTION
This change moves the examples of common shell commands from the ExecuteShellCommandTool description to the general instructions for the assistant. This makes the tool description more concise and the instructions more comprehensive.
