### PR TITLE
feat: Widen sandbox and teach agent about `pwd`

### DIFF
--- a/run.fish
+++ b/run.fish
@@ -6,7 +6,7 @@ uv --project (dirname (status filename)) run coding-assistant \
     --readable-sandbox-directories /mnt/wsl ~/.ssh \
     --writable-sandbox-directories /tmp /dev/shm \
     --mcp-servers \
-        '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{working_directory}"]}' \
+        '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/"]}' \
         '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}' \
         '{"name": "tavily", "command": "npx", "args": ["-y", "tavily-mcp"], "env": ["TAVILY_API_KEY"]}' \
     $argv

--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -20,6 +20,7 @@ INSTRUCTIONS = """
     - `fd` or `find` for searching files
     - `rg` or `grep` for searching text in files
     - `gh` for interfacing with GitHub
+    - `pwd` to get the project root
 """.strip()
 
 PLANNING_INSTRUCTIONS = """


### PR DESCRIPTION
This PR contains the following changes:

- The sandbox directory for the filesystem MCP server has been changed to `/`.
- The `pwd` command has been added to the list of shell commands in the agent's instructions.