### PR TITLE
refactor(tests): update tool confirmation test to use execute_shell_command

### DIFF
--- a/src/coding_assistant/agents/tests/test_agents.py
+++ b/src/coding_assistant/agents/tests/test_agents.py
@@ -158,10 +158,10 @@ async def test_shell_confirmation_negative():
 
 def _create_tool_confirmation_orchestrator():
     config = create_test_config()
-    config.tool_confirmation_patterns = ["^launch_agent"]
+    config.tool_confirmation_patterns = ["^execute_shell_command"]
     tool = OrchestratorTool(config=config)
     parameters = {
-        "task": "Launch an agent to say 'Hello, World!'. If the tool execution is denied, output 'Tool execution denied.'",
+        "task": "Use the execute_shell_command to echo 'Hello, World!'. If the tool execution is denied, output 'Tool execution denied.'",
     }
     return tool, parameters
 

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -68,6 +68,7 @@ class Agent:
 
     tools: list[Tool] = field(default_factory=list)
     mcp_servers: list[MCPServer] = field(default_factory=list)
+    tool_confirmation_patterns: list[str] = field(default_factory=list)
 
     history: list = field(default_factory=list)
     output: AgentOutput | None = None

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -18,3 +18,4 @@ class Config(BaseModel):
     shorten_conversation_at_tokens: int
     enable_ask_user: bool
     shell_confirmation_patterns: List[str]
+    tool_confirmation_patterns: List[str]

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -143,6 +143,12 @@ def parse_args():
         help="Ask for confirmation before executing a shell command that matches any of the given patterns.",
     )
     parser.add_argument(
+        "--tool-confirmation-patterns",
+        nargs="*",
+        default=[],
+        help="Ask for confirmation before executing a tool that matches any of the given patterns.",
+    )
+    parser.add_argument(
         "--wait-for-debugger",
         action=BooleanOptionalAction,
         default=False,
@@ -161,6 +167,7 @@ def create_config_from_args(args) -> Config:
         shorten_conversation_at_tokens=args.shorten_conversation_at_tokens,
         enable_ask_user=args.ask_user,
         shell_confirmation_patterns=args.shell_confirmation_patterns,
+        tool_confirmation_patterns=args.tool_confirmation_patterns,
     )
 
 

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -111,6 +111,7 @@ class OrchestratorTool(Tool):
                 ShortenConversation(),
             ],
             model=self._config.expert_model,
+            tool_confirmation_patterns=self._config.tool_confirmation_patterns,
             feedback_function=lambda agent: _get_feedback(
                 agent=agent,
                 config=self._config,
@@ -187,6 +188,7 @@ class AgentTool(Tool):
                 ShortenConversation(),
             ],
             model=self.get_model(parameters),
+            tool_confirmation_patterns=self._config.tool_confirmation_patterns,
             feedback_function=lambda agent: _get_feedback(
                 agent=agent,
                 config=self._config,
@@ -338,6 +340,7 @@ class FeedbackTool(Tool):
                 ShortenConversation(),
             ],
             model=self._config.model,
+            tool_confirmation_patterns=self._config.tool_confirmation_patterns,
             feedback_function=lambda agent: _get_feedback(
                 agent=agent,
                 config=self._config,


### PR DESCRIPTION
This pull request introduces a new 'tool confirmation' feature. This feature prompts the user for confirmation before executing a tool that matches a certain pattern.