### PR TITLE
MCP adapter improvements and expanded test coverage

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ test:
 
 hello-world:
     ./run.fish \
-      --no-user-feedback --no-feedback-agent \
+    --no-user-feedback \
       --task "Say 'Hello World'"
 
 commit:

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -1,4 +1,4 @@
-import asyncio
+
 import dataclasses
 import json
 import logging

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -23,7 +23,7 @@ class FakeToolCall:
 
 
 async def no_feedback(_: Agent):
-    return None
+    return None  # deprecated; retained for backward compatibility in tests that import it
 
 
 class FakeMessage:
@@ -114,7 +114,6 @@ def make_test_agent(
     model: str = "TestMode",
     description: str = "TestDescription",
     parameters: Sequence[Parameter] | None = None,
-    feedback_function=no_feedback,
     tools: Iterable[Tool] | None = None,
     mcp_servers: list[MCPServer] | None = None,
     tool_confirmation_patterns: list[str] | None = None,
@@ -125,7 +124,6 @@ def make_test_agent(
         model=model,
         description=description,
         parameters=list(parameters) if parameters is not None else [],
-        feedback_function=feedback_function,
         tools=list(tools) if tools is not None else [],
         mcp_servers=list(mcp_servers) if mcp_servers is not None else [],
         tool_confirmation_patterns=list(tool_confirmation_patterns) if tool_confirmation_patterns is not None else [],

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -22,10 +22,6 @@ class FakeToolCall:
     function: FakeFunction
 
 
-async def no_feedback(_: Agent):
-    return None  # deprecated; retained for backward compatibility in tests that import it
-
-
 class FakeMessage:
     def __init__(self, content: str | None = None, tool_calls: list[FakeToolCall] | None = None):
         self.role = "assistant"

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, Mock
 
 from coding_assistant.agents.parameters import Parameter
 from coding_assistant.agents.types import Agent, Tool
+from coding_assistant.llm.model import Completion
 from coding_assistant.tools.mcp import MCPServer
 from coding_assistant.ui import UI
-from coding_assistant.llm.model import Completion
 
 
 @dataclass
@@ -65,7 +65,6 @@ class FakeCompleter:
             raise action
 
         text = action.model_dump_json()
-
         toks = len(text)
         self._total_tokens += toks
 

--- a/src/coding_assistant/agents/tests/test_execution.py
+++ b/src/coding_assistant/agents/tests/test_execution.py
@@ -2,7 +2,7 @@ import pytest
 
 from coding_assistant.agents.callbacks import NullCallbacks
 from coding_assistant.agents.execution import handle_tool_call
-from coding_assistant.agents.tests.helpers import FakeFunction, FakeToolCall, make_test_agent, make_ui_mock, no_feedback
+from coding_assistant.agents.tests.helpers import FakeFunction, FakeToolCall, make_test_agent, make_ui_mock
 from coding_assistant.agents.types import Agent, TextResult, Tool
 
 

--- a/src/coding_assistant/agents/tests/test_model_contract.py
+++ b/src/coding_assistant/agents/tests/test_model_contract.py
@@ -11,7 +11,6 @@ from coding_assistant.agents.tests.helpers import (
     FakeFunction,
     make_test_agent,
     make_ui_mock,
-    no_feedback,
 )
 from coding_assistant.agents.types import Agent, TextResult, Tool
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation

--- a/src/coding_assistant/agents/tests/test_run_loop_slices.py
+++ b/src/coding_assistant/agents/tests/test_run_loop_slices.py
@@ -60,6 +60,7 @@ async def test_tool_selection_then_finish():
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         no_truncate_tools=set(),
+        enable_user_feedback=False,
         completer=completer,
         ui=make_ui_mock(),
     )
@@ -133,6 +134,7 @@ async def test_unknown_tool_error_then_finish(monkeypatch):
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         no_truncate_tools=set(),
+        enable_user_feedback=False,
         completer=completer,
         ui=make_ui_mock(),
     )
@@ -201,6 +203,7 @@ async def test_assistant_message_without_tool_calls_prompts_correction(monkeypat
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         no_truncate_tools=set(),
+        enable_user_feedback=False,
         completer=completer,
         ui=make_ui_mock(),
     )

--- a/src/coding_assistant/agents/tests/test_run_loop_slices.py
+++ b/src/coding_assistant/agents/tests/test_run_loop_slices.py
@@ -11,7 +11,6 @@ from coding_assistant.agents.tests.helpers import (
     FakeToolCall,
     make_test_agent,
     make_ui_mock,
-    no_feedback,
 )
 from coding_assistant.agents.types import Agent, TextResult, Tool
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
@@ -270,18 +269,16 @@ async def test_feedback_loop_then_finish():
             return "Please improve"
         return None
 
-    agent = make_test_agent(
-        tools=[FinishTaskTool(), ShortenConversation()],
-        feedback_function=feedback_once,
-    )
+    agent = make_test_agent(tools=[FinishTaskTool(), ShortenConversation()])
 
     output = await run_agent_loop(
         agent,
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         no_truncate_tools=set(),
+        enable_user_feedback=True,
         completer=completer,
-        ui=make_ui_mock(),
+        ui=make_ui_mock(ask_sequence=[(f"Feedback for {agent.name}", "Please improve"), (f"Feedback for {agent.name}", "Ok")]),
     )
 
     assert output.result == "second"

--- a/src/coding_assistant/agents/tests/test_run_loop_slices.py
+++ b/src/coding_assistant/agents/tests/test_run_loop_slices.py
@@ -264,14 +264,6 @@ async def test_feedback_loop_then_finish():
         ]
     )
 
-    state = {"given_feedback": False}
-
-    async def feedback_once(_agent):
-        if not state["given_feedback"]:
-            state["given_feedback"] = True
-            return "Please improve"
-        return None
-
     agent = make_test_agent(tools=[FinishTaskTool(), ShortenConversation()])
 
     output = await run_agent_loop(
@@ -281,7 +273,9 @@ async def test_feedback_loop_then_finish():
         no_truncate_tools=set(),
         enable_user_feedback=True,
         completer=completer,
-        ui=make_ui_mock(ask_sequence=[(f"Feedback for {agent.name}", "Please improve"), (f"Feedback for {agent.name}", "Ok")]),
+        ui=make_ui_mock(
+            ask_sequence=[(f"Feedback for {agent.name}", "Please improve"), (f"Feedback for {agent.name}", "Ok")]
+        ),
     )
 
     assert output.result == "second"

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Awaitable, Callable, Protocol
+from typing import Awaitable, Protocol
 
 from coding_assistant.agents.callbacks import AgentCallbacks
 from coding_assistant.agents.parameters import Parameter
@@ -63,10 +63,6 @@ class Agent:
 
     description: str
     parameters: list[Parameter]
-
-    # This is a function that can validate an agents output.
-    # If it returns a string, it will be given to the agent as feedback.
-    feedback_function: Callable
 
     tools: list[Tool]
     mcp_servers: list[MCPServer]

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Callable, Protocol, Awaitable
+from typing import Awaitable, Callable, Protocol
 
-from coding_assistant.agents.parameters import Parameter
-from coding_assistant.tools.mcp import MCPServer
 from coding_assistant.agents.callbacks import AgentCallbacks
+from coding_assistant.agents.parameters import Parameter
 from coding_assistant.llm.model import Completion
+from coding_assistant.tools.mcp import MCPServer
 
 
 class ToolResult(ABC):
@@ -77,13 +77,6 @@ class Agent:
 
 
 class Completer(Protocol):
-    """Async callable that produces a model completion.
-
-    Contract:
-    - inputs: conversation messages, model name, tool definitions, and callbacks
-    - output: Completion(message, tokens)
-    """
-
     def __call__(
         self,
         messages: list[dict],
@@ -91,5 +84,4 @@ class Completer(Protocol):
         model: str,
         tools: list,
         callbacks: AgentCallbacks,
-    ) -> Awaitable[Completion]:
-        ...
+    ) -> Awaitable[Completion]: ...

--- a/src/coding_assistant/config.py
+++ b/src/coding_assistant/config.py
@@ -13,7 +13,6 @@ class MCPServerConfig(BaseModel):
 class Config(BaseModel):
     model: str
     expert_model: str
-    enable_feedback_agent: bool
     enable_user_feedback: bool
     shorten_conversation_at_tokens: int
     enable_ask_user: bool

--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -4,6 +4,7 @@ from typing import List
 INSTRUCTIONS = """
 - Do not initialize a new git repository, unless your client explicitly requests it.
 - Do not commit any changes to the git repository, unless your client explicitly requests it.
+- Do not switch branches before asking the user.
 - Do not run anything interactively, e.g. `git rebase -i`.
 - When you have made a change to a project, ask the user if you should commit the changes.
 - Do not install any software on the users computer before asking.

--- a/src/coding_assistant/llm/adapters.py
+++ b/src/coding_assistant/llm/adapters.py
@@ -35,7 +35,7 @@ async def get_tools(tools: list[Tool], mcp_servers: list[MCPServer]) -> list[dic
         List of tool definitions in LiteLLM format
     """
     result = []
-    
+
     # Add tools from the tools list
     for tool in tools:
         if tool.name().startswith("mcp_"):
@@ -54,22 +54,23 @@ async def get_tools(tools: list[Tool], mcp_servers: list[MCPServer]) -> list[dic
     
     # Add tools from MCP servers
     for server in mcp_servers:
-        for _, tool_list in await server.session.list_tools():
-            for mcp_tool in tool_list or []:
-                tool_id = f"mcp_{server.name}_{mcp_tool.name}"
+        tools_response = await server.session.list_tools()
+        server_tools = getattr(tools_response, "tools", [])
+        for mcp_tool in server_tools or []:
+            tool_id = f"mcp_{server.name}_{mcp_tool.name}"
 
-                fix_input_schema(mcp_tool.inputSchema)
+            fix_input_schema(mcp_tool.inputSchema)
 
-                result.append(
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": tool_id,
-                            "description": mcp_tool.description,
-                            "parameters": mcp_tool.inputSchema,
-                        },
-                    }
-                )
+            result.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool_id,
+                        "description": mcp_tool.description,
+                        "parameters": mcp_tool.inputSchema,
+                    },
+                }
+            )
     
     return result
 

--- a/src/coding_assistant/llm/adapters.py
+++ b/src/coding_assistant/llm/adapters.py
@@ -5,7 +5,6 @@ This module contains functions that adapt various tool representations
 (MCP servers, Tool instances) to the format expected by LiteLLM.
 """
 
-from typing import List
 
 from coding_assistant.agents.types import Tool, TextResult, ToolResult
 from coding_assistant.tools.mcp import MCPServer, handle_mcp_tool_call
@@ -17,10 +16,10 @@ def fix_input_schema(input_schema: dict):
     This is a workaround for the fact that Gemini API does not support certain values for the `format` field
     """
 
-    for property in input_schema.get("properties", {}).values():
-        if (format := property.get("format")) and format == "uri":
+    for prop in input_schema.get("properties", {}).values():
+        if (format := prop.get("format")) and format == "uri":
             # Gemini API does not support `format: uri`, so we remove it
-            property.pop("format", None)
+            prop.pop("format", None)
 
 
 async def get_tools(tools: list[Tool], mcp_servers: list[MCPServer]) -> list[dict]:
@@ -89,7 +88,7 @@ async def execute_tool_call(function_name: str, function_args: dict, tools: list
         ToolResult from the executed tool
 
     Raises:
-        RuntimeError: If the tool is not found
+        ValueError: If a regular tool is not found
     """
     if function_name.startswith("mcp_"):
         content = await handle_mcp_tool_call(function_name, function_args, mcp_servers)

--- a/src/coding_assistant/llm/adapters.py
+++ b/src/coding_assistant/llm/adapters.py
@@ -17,7 +17,8 @@ def fix_input_schema(input_schema: dict):
     """
 
     for prop in input_schema.get("properties", {}).values():
-        if (format := prop.get("format")) and format == "uri":
+        fmt = prop.get("format")
+        if fmt == "uri":
             # Gemini API does not support `format: uri`, so we remove it
             prop.pop("format", None)
 

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -57,8 +57,8 @@ def parse_args():
         help="Resume from a specific orchestrator history file.",
     )
     parser.add_argument("--print-mcp-tools", action="store_true", help="Print all available tools from MCP servers.")
-    parser.add_argument("--model", type=str, default="gpt-4.1", help="Model to use for the orchestrator agent.")
-    parser.add_argument("--expert-model", type=str, default="gpt-4.1", help="Expert model to use.")
+    parser.add_argument("--model", type=str, default="gpt-5", help="Model to use for the orchestrator agent.")
+    parser.add_argument("--expert-model", type=str, default="gpt-5", help="Expert model to use.")
     parser.add_argument(
         "--user-feedback",
         action=BooleanOptionalAction,

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -60,12 +60,6 @@ def parse_args():
     parser.add_argument("--model", type=str, default="gpt-4.1", help="Model to use for the orchestrator agent.")
     parser.add_argument("--expert-model", type=str, default="gpt-4.1", help="Expert model to use.")
     parser.add_argument(
-        "--feedback-agent",
-        action=BooleanOptionalAction,
-        default=False,
-        help="Enable the feedback agent.",
-    )
-    parser.add_argument(
         "--user-feedback",
         action=BooleanOptionalAction,
         default=True,
@@ -169,7 +163,6 @@ def create_config_from_args(args) -> Config:
     return Config(
         model=args.model,
         expert_model=args.expert_model,
-        enable_feedback_agent=args.feedback_agent,
         enable_user_feedback=args.user_feedback,
         shorten_conversation_at_tokens=args.shorten_conversation_at_tokens,
         enable_ask_user=args.ask_user,

--- a/src/coding_assistant/tests/test_adapters.py
+++ b/src/coding_assistant/tests/test_adapters.py
@@ -1,0 +1,64 @@
+import pytest
+
+from coding_assistant.agents.types import TextResult, Tool
+from coding_assistant.llm import adapters
+
+
+class DummyTool(Tool):
+    def __init__(self, name: str, result: str):
+        self._name = name
+        self._result = result
+
+    def name(self) -> str:
+        return self._name
+
+    def description(self) -> str:
+        return "desc"
+
+    def parameters(self) -> dict:
+        return {}
+
+    async def execute(self, parameters: dict) -> TextResult:
+        return TextResult(content=self._result)
+
+
+def test_fix_input_schema_removes_uri_format():
+    schema = {
+        "type": "object",
+        "properties": {
+            "url": {"type": "string", "format": "uri"},
+            "other": {"type": "string"},
+        },
+    }
+
+    adapters.fix_input_schema(schema)
+
+    assert "format" not in schema["properties"]["url"]
+    assert "format" not in schema["properties"]["other"]  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_mcp_branch(monkeypatch):
+    # Patch handle_mcp_tool_call used inside adapters
+    async def _fake_handle(name, args, servers):
+        return f"called {name} with {args}"
+
+    monkeypatch.setattr(adapters, "handle_mcp_tool_call", _fake_handle)
+
+    res = await adapters.execute_tool_call(
+        "mcp_server_tool", {"a": 1}, tools=[], mcp_servers=[]
+    )
+    assert isinstance(res, TextResult)
+    assert res.content == "called mcp_server_tool with {'a': 1}"
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_call_regular_tool_and_not_found():
+    tool = DummyTool("echo", "ok")
+
+    res = await adapters.execute_tool_call("echo", {}, tools=[tool], mcp_servers=[])
+    assert isinstance(res, TextResult)
+    assert res.content == "ok"
+
+    with pytest.raises(ValueError, match="Tool missing not found"):
+        await adapters.execute_tool_call("missing", {}, tools=[tool], mcp_servers=[])

--- a/src/coding_assistant/tests/test_get_tools.py
+++ b/src/coding_assistant/tests/test_get_tools.py
@@ -1,0 +1,78 @@
+import pytest
+from typing import cast
+
+from types import SimpleNamespace
+
+from coding_assistant.agents.types import Tool
+from coding_assistant.llm.adapters import get_tools
+from coding_assistant.tools.mcp import MCPServer
+from mcp import ClientSession
+
+
+class _DummyTool(Tool):
+    def name(self) -> str:
+        return "echo"
+
+    def description(self) -> str:
+        return "desc"
+
+    def parameters(self) -> dict:
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, parameters: dict):
+        raise NotImplementedError
+
+
+class _McpTool:
+    def __init__(self, name: str, description: str, input_schema: dict):
+        self.name = name
+        self.description = description
+        self.inputSchema = input_schema
+
+
+class _FakeMcpSession:
+    def __init__(self, tools):
+        self._tools = tools
+
+    async def list_tools(self):
+        # Mimic MCP response with attribute 'tools'
+        return SimpleNamespace(tools=self._tools)
+
+
+@pytest.mark.asyncio
+async def test_get_tools_combines_regular_and_mcp_and_fixes_schema():
+    regular = _DummyTool()
+
+    mcp_tool = _McpTool(
+        name="download",
+        description="Download a URL",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "format": "uri"},
+            },
+            "required": ["url"],
+        },
+    )
+
+    mcp_server = MCPServer(name="srv", session=cast(ClientSession, _FakeMcpSession([mcp_tool])), instructions=None)
+
+    tools = await get_tools([regular], [mcp_server])
+
+    # Expect 2 tools, first regular, second MCP
+    names = [t["function"]["name"] for t in tools]
+    assert names == ["echo", "mcp_srv_download"]
+
+    # Check schema fix applied (format removed)
+    mcp_params = tools[1]["function"]["parameters"]
+    assert "format" not in mcp_params["properties"]["url"]
+
+
+@pytest.mark.asyncio
+async def test_get_tools_rejects_regular_tool_with_mcp_prefix():
+    class BadTool(_DummyTool):
+        def name(self) -> str:
+            return "mcp_bad"
+
+    with pytest.raises(ValueError, match="Tools cannot start with mcp_"):
+        await get_tools([BadTool()], [])

--- a/src/coding_assistant/tests/test_mcp.py
+++ b/src/coding_assistant/tests/test_mcp.py
@@ -1,0 +1,59 @@
+import os
+from typing import cast
+import pytest
+
+from mcp import ClientSession
+from coding_assistant.tools.mcp import MCPServer, get_default_env, handle_mcp_tool_call
+
+
+class _ResultContent:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _CallToolResult:
+    def __init__(self, content: list[_ResultContent] | None):
+        self.content = content
+
+
+class _FakeSession:
+    def __init__(self, name: str, responses: dict[str, _CallToolResult]):
+        self._name = name
+        self._responses = responses
+
+    async def call_tool(self, tool_name: str, arguments: dict):
+        return self._responses.get(tool_name, _CallToolResult(content=None))
+
+
+@pytest.mark.asyncio
+async def test_handle_mcp_tool_call_happy_path():
+    session = _FakeSession(
+        name="server1",
+        responses={"echo": _CallToolResult([_ResultContent("hello")])},
+    )
+    servers = [MCPServer(name="server1", session=cast(ClientSession, session), instructions=None)]
+
+    content = await handle_mcp_tool_call("mcp_server1_echo", {"msg": "ignored"}, servers)
+    assert content == "hello"
+
+
+@pytest.mark.asyncio
+async def test_handle_mcp_tool_call_no_content_returns_message():
+    session = _FakeSession(name="server1", responses={"empty": _CallToolResult(content=None)})
+    servers = [MCPServer(name="server1", session=cast(ClientSession, session), instructions=None)]
+
+    content = await handle_mcp_tool_call("mcp_server1_empty", {}, servers)
+    assert content == "MCP server did not return any content."
+
+
+@pytest.mark.asyncio
+async def test_handle_mcp_tool_call_server_not_found():
+    servers = [MCPServer(name="serverA", session=cast(ClientSession, _FakeSession("serverA", {})), instructions=None)]
+    with pytest.raises(RuntimeError, match="Server serverB not found"):
+        await handle_mcp_tool_call("mcp_serverB_echo", {}, servers)
+
+
+def test_get_default_env_includes_https_proxy(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:8080")
+    env = get_default_env()
+    assert env.get("HTTPS_PROXY") == "http://proxy:8080"

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -20,11 +20,9 @@ from coding_assistant.agents.types import (
 )
 from coding_assistant.config import Config
 from coding_assistant.llm.model import complete
+from coding_assistant.ui import UI, NullUI
 
 logger = logging.getLogger(__name__)
-
-
-from coding_assistant.ui import UI, NullUI
 
 
 async def _get_feedback(

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
-from coding_assistant.agents.callbacks import AgentCallbacks, NullCallbacks
+from coding_assistant.agents.callbacks import AgentCallbacks
 from coding_assistant.agents.execution import run_agent_loop
 from coding_assistant.agents.parameters import fill_parameters
 from coding_assistant.agents.types import (

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import re
-import textwrap
 from typing import List, Optional
 
 from pydantic import BaseModel, Field
@@ -27,35 +26,18 @@ logger = logging.getLogger(__name__)
 
 async def _get_feedback(
     agent: Agent,
-    config: Config,
-    mcp_servers: list,
-    enable_feedback_agent: bool,
     enable_user_feedback: bool,
     ui: UI,
-    agent_callbacks: AgentCallbacks,
 ) -> str | None:
     if not agent.output:
         raise ValueError("Agent has no result to provide feedback on.")
 
-    feedback = "Ok"
-
-    if enable_feedback_agent:
-        feedback_tool = FeedbackTool(config=config, mcp_servers=mcp_servers, agent_callbacks=agent_callbacks, ui=ui)
-        formatted_parameters = textwrap.indent(format_parameters(agent.parameters), "  ")
-        agent_feedback_result = await feedback_tool.execute(
-            parameters={
-                "description": agent.description,
-                "parameters": "\n" + formatted_parameters,
-                "result": agent.output.result,
-                "summary": agent.output.summary,
-            }
-        )
-        feedback = agent_feedback_result.content
+    feedback: str | None = None
 
     if enable_user_feedback:
-        feedback = await ui.ask(f"Feedback for {agent.name}", default=feedback)
+        feedback = await ui.ask(f"Feedback for {agent.name}", default="Ok")
 
-    return feedback if feedback != "Ok" else None
+    return feedback if feedback and feedback != "Ok" else None
 
 
 class LaunchOrchestratorAgentSchema(BaseModel):
@@ -111,11 +93,7 @@ class OrchestratorTool(Tool):
             tool_confirmation_patterns=self._config.tool_confirmation_patterns,
             feedback_function=lambda agent: _get_feedback(
                 agent=agent,
-                config=self._config,
-                mcp_servers=self._mcp_servers,
-                enable_feedback_agent=self._config.enable_feedback_agent,
                 enable_user_feedback=self._config.enable_user_feedback,
-                agent_callbacks=self._agent_callbacks,
                 ui=self._ui,
             ),
         )
@@ -191,11 +169,7 @@ class AgentTool(Tool):
             tool_confirmation_patterns=self._config.tool_confirmation_patterns,
             feedback_function=lambda agent: _get_feedback(
                 agent=agent,
-                config=self._config,
-                mcp_servers=self._mcp_servers,
-                enable_feedback_agent=self._config.enable_feedback_agent,
                 enable_user_feedback=self._config.enable_user_feedback,
-                agent_callbacks=self._agent_callbacks,
                 ui=self._ui,
             ),
         )
@@ -304,68 +278,6 @@ class ExecuteShellCommandTool(Tool):
                 indent=2,
             )
         )
-
-
-class LaunchFeedbackAgentSchema(BaseModel):
-    description: str = Field(description="The description of the agent that was working on the task.")
-    parameters: str = Field(description="The parameters the agent was given for the task.")
-    result: str = Field(description="The result of the agent.")
-    summary: str | None = Field(default=None, description="A summary of the conversation with the client.")
-
-
-class FeedbackTool(Tool):
-    def __init__(self, config: Config, mcp_servers: list, agent_callbacks: AgentCallbacks, ui: UI):
-        super().__init__()
-        self._config = config
-        self._mcp_servers = mcp_servers
-        self._agent_callbacks = agent_callbacks
-        self._ui = ui
-
-    def name(self) -> str:
-        return "launch_feedback_agent"
-
-    def description(self) -> str:
-        return "Launch a feedback agent that provides feedback on the output of another agent. This agent evaluates whether the result is acceptable for a given description, parameters, summary and feedback. The agent will evaluate the result as if it were a paying client. The feedback agent will thoroughly review every change that is described and will look at file system, git history, etc. as it deems necessary. If the result is acceptable, the feedback agent will call `finish_task` with the result being 'Ok'. Otherwise, it will output what is wrong with the result and how it needs to be improved."
-
-    def parameters(self) -> dict:
-        return LaunchFeedbackAgentSchema.model_json_schema()
-
-    async def execute(self, parameters: dict) -> TextResult:
-        feedback_agent = Agent(
-            name="Feedback",
-            description=self.description(),
-            parameters=fill_parameters(
-                parameter_description=self.parameters(),
-                parameter_values=parameters,
-            ),
-            mcp_servers=self._mcp_servers,
-            tools=[
-                ExecuteShellCommandTool(self._config.shell_confirmation_patterns, ui=self._ui),
-                FinishTaskTool(),
-                ShortenConversation(),
-            ],
-            model=self._config.model,
-            tool_confirmation_patterns=self._config.tool_confirmation_patterns,
-            feedback_function=lambda agent: _get_feedback(
-                agent=agent,
-                config=self._config,
-                mcp_servers=self._mcp_servers,
-                enable_feedback_agent=False,
-                enable_user_feedback=False,
-                agent_callbacks=self._agent_callbacks,
-                ui=self._ui,
-            ),
-        )
-
-        output = await run_agent_loop(
-            feedback_agent,
-            self._agent_callbacks,
-            self._config.shorten_conversation_at_tokens,
-            self._config.no_truncate_tools,
-            completer=complete,
-            ui=self._ui,
-        )
-        return TextResult(content=output.result)
 
 
 class FinishTaskSchema(BaseModel):


### PR DESCRIPTION
Summary
- Align MCP tool discovery with MCP client response shape (uses tools_response.tools)
- Generate stable MCP tool IDs (mcp_{server}_{tool}) and reject regular tools using the mcp_ prefix
- Make MCP tool schemas LLM-compatible by stripping unsupported format: uri values
- Add unit tests for adapters, MCP handling, and get_tools; test suite now at 65 passing tests
- Minor cleanups in imports and UI wiring

Implementation notes
- adapters.get_tools reads tools from the list_tools response and fixes input schemas before exposing them
- execute_tool_call routes MCP-prefixed calls via handle_mcp_tool_call and returns TextResult; raises ValueError for unknown regular tools
- tools.mcp.handle_mcp_tool_call returns a friendly message when no content is returned by the server

Verification
- just test -> 65 passed locally
- Branch ms/update has a clean working tree and diffs cleanly against master

Follow-ups (non-blocking)
- Remove an unused typing import in llm/adapters.py
- Consider renaming local variables in fix_input_schema to avoid shadowing built-ins
- Update a docstring in execute_tool_call to match actual exceptions raised
- Make tools.mcp.print_mcp_tools resilient if list_tools response shape varies
