### PR TITLE
Refactor callbacks; improve tool-call telemetry; clarify sub-agent context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,162 @@
 # Coding Assistant
 
-**Coding Assistant** is an advanced Python-based tool that leverages agent-based automation to streamline, support, and automate various coding tasks.
+Coding Assistant is a Python-based, agent-orchestrated CLI that helps you automate and streamline coding tasks. It can plan, launch sub-agents, use MCP tools (filesystem, web fetch/search, Context7, Tavily, etc.), run inside a sandbox, keep resumable history, and optionally emit OTLP traces for observability.
 
 ## Key Features
 
-- **Agent Orchestration**: The Orchestrator agent coordinates tasks by delegating work to specialized sub-agents.
-- **Resume Functionality**: Resume work from a previous session.
-- **Project-Specific Caching**: Conversation history is cached within a `.coding_assistant` directory in your project.
-- **Flexible CLI**: Launch, control, and interact with agents from the command line.
-- **MCP Server Integration**: Native support for MCP server toolchains (filesystem, fetch/web search, git, Tavily, etc).
-- **Sandbox Security**: Landlock-based filesystem sandbox for secure task execution.
-- **Shell Command Confirmation**: Prompts for user confirmation before executing potentially harmful shell commands.
+- Orchestrator agent that delegates to sub-agents and tools
+- Resumable sessions and conversation summaries stored per-project
+- MCP Server integration out of the box (filesystem, fetch, context7, tavily examples)
+- Landlock-based filesystem sandbox with readable/writable allowlists
+- Prompt-toolkit powered TUI with optional model chunks and reasoning display
+- Shell/tool confirmation patterns to guard dangerous operations
+- Configurable via CLI flags (models, planning mode, instructions, etc.)
+- Optional OTLP tracing (exporter over HTTP)
+
+## Requirements
+
+- Python 3.12+
+- uv (recommended) or pip for running/installing
+- Optional: fish shell if you want to use the provided `run.fish`
+- For the example MCP servers used in `run.fish`:
+  - Node.js/npm for `npx`
+  - Network access to fetch packages
+- API keys as needed by your chosen model/tooling, e.g.:
+  - `OPENAI_API_KEY` (or other LiteLLM-compatible provider keys)
+  - `TAVILY_API_KEY` (for the Tavily MCP server)
 
 ## Installation
 
-1.  **Clone the repository:**
-    ```bash
-    git clone <REPO_URL>
-    cd coding_assistant
-    ```
-2.  **Set environment variables:**
-    -   Set up environment variables for API keys (e.g., `OPENAI_API_KEY`, `GEMINI_API_KEY`).
-    -   You can use a `.envrc` file with `direnv` or export them manually.
+Using uv (recommended):
+
+```bash
+# In the repo root
+uv sync  # or: uv pip install -e .
+```
+
+Using pip:
+
+```bash
+pip install -e .
+```
 
 ## Quickstart
 
-Run the assistant using the `run.fish` script, which handles everything for you.
+The easiest way to run is with the provided script, which preconfigures several MCP servers and sensible defaults:
 
-**Basic Usage:**
-```bash
-./run.fish --task "Refactor all function names to snake_case."
-```
-
-**Hello World:**
 ```bash
 ./run.fish --task "Say 'Hello World'"
 ```
 
-**Resume Last Session:**
+A more realistic example:
+
+```bash
+./run.fish --task "Refactor all function names to snake_case."
+```
+
+Resume the last session:
+
 ```bash
 ./run.fish --task "Continue with the previous task." --resume
 ```
 
-For more options, run:
+Show available options:
+
 ```bash
 ./run.fish --help
 ```
+
+### Running without run.fish
+
+You can invoke the CLI directly (e.g., using uv):
+
+```bash
+uv run coding-assistant \
+  --task "Say 'Hello World'" \
+  --model "gpt-5" \
+  --expert-model "gpt-5" \
+  --mcp-servers '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem@2025.7.29", "/"]}' \
+  --mcp-servers '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch@2025.4.7"]}' \
+  --mcp-servers '{"name": "context7", "command": "npx", "args": ["-y", "@upstash/context7-mcp@1.0.14"], "env": []}' \
+  --mcp-servers '{"name": "tavily", "command": "npx", "args": ["-y", "tavily-mcp@0.2.9"], "env": ["TAVILY_API_KEY"]}'
+```
+
+Notes:
+- Model names are routed via LiteLLM. Use any provider/model you have keys for; set the corresponding API key env vars.
+- The `--mcp-servers` values are JSON strings; see below for details.
+
+## Usage Highlights
+
+- `--task` The task for the orchestrator agent (required).
+- `--resume`/`--resume-file` Resume from the latest/specific orchestrator history in `.coding_assistant/history/`.
+- `--model`/`--expert-model` Select models for general/expert tasks.
+- `--plan` Enable planning mode to build a stepwise plan before acting.
+- `--instructions` Provide extra instructions that are composed with defaults.
+- `--print-chunks`/`--print-reasoning` Control live stream and reasoning display in the TUI.
+- `--shell-confirmation-patterns` Ask for confirmation before running matching shell commands.
+- `--tool-confirmation-patterns` Ask for confirmation before running matching tools.
+- `--no-truncate-tools` List of regex patterns for tools whose output should not be truncated.
+- `--wait-for-debugger` Wait for a debugger (debugpy) to attach on port 1234.
+
+Run `coding-assistant --help` to see all options.
+
+## MCP Servers
+
+Pass MCP servers with repeated `--mcp-servers` flags as JSON strings:
+
+```json
+{
+  "name": "filesystem",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem@2025.7.29", "/"]
+}
+```
+
+The `run.fish` script includes these examples:
+- filesystem: `@modelcontextprotocol/server-filesystem@2025.7.29`
+- fetch: `mcp-server-fetch@2025.4.7` (via `uvx`)
+- context7: `@upstash/context7-mcp@1.0.14`
+- tavily: `tavily-mcp@0.2.9` (needs `TAVILY_API_KEY`)
+
+You can print discovered tools from running MCP servers:
+
+```bash
+uv run coding-assistant --print-mcp-tools ...
+```
+
+## Sandbox
+
+When enabled (default), the assistant applies Landlock restrictions. By default it adds:
+- Readable directories: your active virtual environment and any passed via `--readable-sandbox-directories`.
+- Writable directories: the current working directory and any passed via `--writable-sandbox-directories`.
+
+Use these flags to widen access if needed when working across multiple directories or mounts.
+
+## History and Resume
+
+- Conversation history and summaries are kept under `.coding_assistant/` in your project.
+- Use `--resume` to continue from the most recent session, or `--resume-file` to select a specific file.
+- The assistant automatically trims old history once it’s saved.
+
+## Tracing (optional)
+
+If `--trace-endpoint` is reachable (default `http://localhost:4318/v1/traces`), OTLP traces are exported using the HTTP exporter. If unreachable, tracing is disabled automatically.
+
+## Development
+
+- Run tests:
+
+  ```bash
+  just test
+  ```
+
+  or
+
+  ```bash
+  uv run pytest -n auto -m "not slow"
+  ```
+
+- Handy `just` recipes: `hello-world`, `commit`, `review`, `pr` (see `justfile`).
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,1 @@
+- [ ] Try to use tmux to run sub-agents.

--- a/src/coding_assistant/agents/callbacks.py
+++ b/src/coding_assistant/agents/callbacks.py
@@ -49,11 +49,6 @@ class AgentCallbacks(ABC):
         pass
 
     @abstractmethod
-    def on_tool_start(self, agent_name: str, tool_name: str, arguments: dict):
-        """Called right before a tool is executed."""
-        pass
-
-    @abstractmethod
     def on_chunk(self, chunk: str):
         """Handle LLM chunks."""
         pass
@@ -83,9 +78,6 @@ class NullCallbacks(AgentCallbacks):
         pass
 
     def on_tool_message(self, agent_name: str, tool_name: str, arguments: dict, result: str):
-        pass
-
-    def on_tool_start(self, agent_name: str, tool_name: str, arguments: dict):
         pass
 
     def on_chunk(self, chunk: str):
@@ -183,19 +175,6 @@ class RichCallbacks(AgentCallbacks):
             Panel(
                 render_group,
                 title=f"Agent {agent_name} tool call",
-                border_style="yellow",
-            ),
-        )
-
-    def on_tool_start(self, agent_name: str, tool_name: str, arguments: dict):
-        render_group = Group(
-            Markdown(f"Name: `{tool_name}`"),
-            Padding(Pretty(arguments, expand_all=True, indent_size=2), (1, 0, 0, 0)),
-        )
-        print(
-            Panel(
-                render_group,
-                title=f"Agent {agent_name} tool start",
                 border_style="yellow",
             ),
         )

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -141,10 +141,12 @@ async def handle_tool_call(
                 return
 
     trace.get_current_span().set_attribute("function.name", function_name)
-    trace.get_current_span().set_attribute("function.args", args_str)
+    trace.get_current_span().set_attribute("function.args", json.dumps(function_args))
+
+    logger.info(f"[{tool_call.id}] [{agent.name}] Calling tool '{function_name}' with arguments {function_args}")
 
     try:
-        function_call_result = await execute_tool_call(function_name, function_args, list(agent.tools))
+        function_call_result = await execute_tool_call(function_name, function_args, agent.tools)
     except ValueError as e:
         append_tool_message(
             agent.history,

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -112,7 +112,7 @@ async def handle_tool_call(
     args_str = tool_call.function.arguments or "{}"
     try:
         function_args = json.loads(args_str)
-    except (JSONDecodeError, TypeError) as e:
+    except JSONDecodeError as e:
         append_tool_message(
             agent.history,
             agent_callbacks,
@@ -143,8 +143,6 @@ async def handle_tool_call(
     trace.get_current_span().set_attribute("function.name", function_name)
     trace.get_current_span().set_attribute("function.args", args_str)
 
-    agent_callbacks.on_tool_start(agent.name, function_name, function_args)
-
     try:
         function_call_result = await execute_tool_call(function_name, function_args, list(agent.tools))
     except ValueError as e:
@@ -159,7 +157,6 @@ async def handle_tool_call(
         )
         return
 
-    assert function_call_result is not None, f"Function {function_name} not implemented"
     trace.get_current_span().set_attribute("function.result", str(function_call_result))
 
     result_handlers = {

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -119,7 +119,7 @@ async def handle_tool_call(
             agent.name,
             tool_call.id,
             function_name,
-            args_str,
+            dict(),
             f"Error: Tool call arguments {args_str} are not valid JSON: {e}",
         )
         return
@@ -217,7 +217,6 @@ async def handle_tool_calls(
         for task in done:
             await task
 
-        agent_callbacks.on_tools_progress([t.get_name() for t in pending])
         if not pending:
             break
 

--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -21,6 +21,7 @@ INSTRUCTIONS = """
 - Make use of sub-agents.
     - Do not read lots of files, if you want to know something about the codebase, launch a sub-agent.
     - When possible, launch multiple sub-agents in parallel to speed up your work.
+    - It is *very* important to pass all necessary context to the sub-agent, they do **not** have access to your conversation history with the client. The only thing they see is the parameters you pass to them.
     - You are responsible for the work of the sub-agents. Review it before showing it to the client.
 - For big tasks, create a plan with multiple steps.
     - Ask the user for feedback on the plan before implementing it.

--- a/src/coding_assistant/tests/test_history_public.py
+++ b/src/coding_assistant/tests/test_history_public.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+from datetime import datetime, timedelta
+
+import pytest
+
+from coding_assistant.history import (
+    get_project_cache_dir,
+    get_conversation_history_file,
+    get_conversation_summaries,
+    save_conversation_summary,
+    get_orchestrator_history_dir,
+    save_orchestrator_history,
+    get_latest_orchestrator_history_file,
+    load_orchestrator_history,
+    clear_orchestrator_history,
+    trim_orchestrator_history,
+)
+
+
+def test_conversation_summaries_roundtrip(tmp_path: Path):
+    wd = tmp_path
+
+    # Initially none
+    assert get_conversation_summaries(wd) == []
+
+    # Save two summaries and read back
+    save_conversation_summary(wd, "first")
+    save_conversation_summary(wd, "second")
+    assert get_conversation_summaries(wd) == ["first", "second"]
+
+    # Files exist in expected location
+    path = get_conversation_history_file(wd)
+    assert path.exists()
+
+
+def test_orchestrator_history_roundtrip_and_trim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    wd = tmp_path
+
+    # Directory creation helpers should work
+    cache_dir = get_project_cache_dir(wd)
+    assert cache_dir.exists()
+    hist_dir = get_orchestrator_history_dir(wd)
+    assert hist_dir.exists()
+
+    # Ensure unique filenames by faking datetime.now()
+    base = datetime(2024, 1, 1, 0, 0, 0)
+    times = [base + timedelta(seconds=i) for i in range(12)]
+
+    class _FakeDT:
+        def now(self):
+            return times.pop(0)
+
+    monkeypatch.setattr("coding_assistant.history.datetime", _FakeDT(), raising=False)
+
+    # Save multiple histories
+    for i in range(12):
+        save_orchestrator_history(wd, [{"role": "user", "content": f"msg-{i}"}])
+
+    # Latest file available
+    latest = get_latest_orchestrator_history_file(wd)
+    assert latest is not None and latest.exists()
+    data = load_orchestrator_history(latest)
+    assert isinstance(data, list) and data[-1]["content"].startswith("msg-")
+
+    # Trim to keep 5 most recent
+    trim_orchestrator_history(wd, keep=5)
+    assert len(list(hist_dir.glob("history_*.json"))) == 5
+
+    # Clear all
+    clear_orchestrator_history(wd)
+    assert len(list(hist_dir.glob("history_*.json"))) == 0
+
+
+def test_save_orchestrator_history_strips_trailing_assistant_tool_calls(tmp_path: Path):
+    wd = tmp_path
+    # An invalid history with trailing assistant tool_call should be fixed on save
+    invalid = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "Thinking...",
+            "tool_calls": [{"id": "1", "function": {"name": "x", "arguments": "{}"}}],
+        },
+    ]
+
+    save_orchestrator_history(wd, invalid)
+    latest = get_latest_orchestrator_history_file(wd)
+    fixed = load_orchestrator_history(latest)
+    assert fixed == [{"role": "user", "content": "hi"}]

--- a/src/coding_assistant/tests/test_instructions_public.py
+++ b/src/coding_assistant/tests/test_instructions_public.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from coding_assistant.instructions import get_instructions
+
+
+def test_get_instructions_base_and_user_instructions(tmp_path: Path):
+    wd = tmp_path
+    # No local file, no planning
+    instr = get_instructions(working_directory=wd, plan=False, user_instructions=["  A  ", "B\n"])
+
+    # Key baseline rules should be present
+    assert "Do not initialize a new git repository" in instr
+    # User instructions appended, trimmed and in order
+    assert "\nA\n" in instr
+    # Second item may be at end without trailing newline
+    assert "\nB\n" in instr or instr.rstrip().endswith("\nB") or instr.endswith("B")
+
+
+def test_get_instructions_with_planning_and_local_file(tmp_path: Path):
+    wd = tmp_path
+    local_dir = wd / ".coding_assistant"
+    local_dir.mkdir()
+    (local_dir / "instructions.md").write_text("LOCAL OVERRIDE\n- extra rule")
+
+    instr = get_instructions(working_directory=wd, plan=True, user_instructions=[])
+
+    # Planning block should be included
+    assert "You are in planning mode." in instr
+    # Local instructions appended
+    assert "LOCAL OVERRIDE" in instr
+    assert "- extra rule" in instr

--- a/src/coding_assistant/tests/test_llm_model_public.py
+++ b/src/coding_assistant/tests/test_llm_model_public.py
@@ -1,0 +1,85 @@
+import asyncio
+import types
+import pytest
+
+from coding_assistant.llm import model as llm_model
+from coding_assistant.agents.callbacks import AgentCallbacks
+
+
+class _CB(AgentCallbacks):
+    def __init__(self):
+        self.chunks = []
+        self.end = False
+        self.reasoning = []
+
+    def on_agent_start(self, agent_name: str, model: str, is_resuming: bool = False):
+        pass
+
+    def on_agent_end(self, agent_name: str, result: str, summary: str):
+        pass
+
+    def on_user_message(self, agent_name: str, content: str):
+        pass
+
+    def on_assistant_message(self, agent_name: str, content: str):
+        pass
+
+    def on_assistant_reasoning(self, agent_name: str, content: str):
+        self.reasoning.append(content)
+
+    def on_tool_message(self, agent_name: str, tool_name: str, arguments: dict, result: str):
+        pass
+
+    def on_chunk(self, chunk: str):
+        self.chunks.append(chunk)
+
+    def on_chunks_end(self):
+        self.end = True
+
+
+@pytest.mark.asyncio
+async def test_complete_streaming_happy_path(monkeypatch):
+    # Build a fake async generator that yields chunks with delta.content
+    async def fake_acompletion(**kwargs):
+        async def agen():
+            yield {"choices": [{"delta": {"content": "Hello"}}]}
+            yield {"choices": [{"delta": {"content": " world"}}]}
+        return agen()
+
+    def fake_stream_chunk_builder(chunks):
+        # Simulate final message with model_dump_json available
+        class _Msg:
+            def __init__(self):
+                self.content = "Hello world"
+            def model_dump(self):
+                return {"role": "assistant", "content": self.content}
+        return {"choices": [{"message": _Msg()}], "usage": {"total_tokens": 42}}
+
+    monkeypatch.setattr(llm_model.litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(llm_model.litellm, "stream_chunk_builder", fake_stream_chunk_builder)
+
+    cb = _CB()
+    comp = await llm_model.complete(messages=[], model="m", tools=[], callbacks=cb)
+
+    # Chunks were forwarded and end signaled
+    assert cb.chunks == ["Hello", " world"]
+    assert cb.end is True
+
+    # Completion assembled
+    assert comp.tokens == 42
+    assert comp.message.content == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_complete_error_path_logs_and_raises(monkeypatch):
+    class Boom(Exception):
+        pass
+
+    async def fake_acompletion(**kwargs):
+        raise Boom("fail")
+
+    monkeypatch.setattr(llm_model.litellm, "acompletion", fake_acompletion)
+
+    cb = _CB()
+    with pytest.raises(Boom):
+        await llm_model.complete(messages=[{"role": "user", "content": "x"}], model="m", tools=[], callbacks=cb)


### PR DESCRIPTION
Summary
- Remove on_tool_start and on_tools_progress callbacks and their Rich UI usage.
- Replace tool-start/progress display with structured logging and OTEL span attributes.
- Persist tool-call arguments to OTEL attribute function.args as compact JSON.
- Clarify instructions to always pass full context to sub-agents.
- Update tests to drop callbacks-specific expectations.

Changes
- src/coding_assistant/agents/callbacks.py: remove abstract methods and Rich Live-based progress.
- src/coding_assistant/agents/execution.py: update telemetry, remove progress hooks, pass agent.tools directly to execute_tool_call.
- src/coding_assistant/agents/tests/test_callbacks_integration.py: remove on_tool_start test.
- src/coding_assistant/instructions.py: add sub-agent context note.

Testing
- just test: 77 passed locally.

Risks/Notes
- If any downstream code depended on the removed callbacks, it will need migration.
- Minor risk: arguments type edge case; consider catching TypeError when tool-call arguments are not strings.

Follow-ups
- Optional: investigate and clean up the “origin/master is ambiguous” warning.
- Consider adding coverage for error paths in execution.py.
