### PR TITLE
Improve tool-call tracing, refine shell command truncation, align callbacks and typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ uv run coding-assistant \
   --task "Say 'Hello World'" \
   --model "gpt-5" \
   --expert-model "gpt-5" \
-  --mcp-servers '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem@2025.7.29", "/"]}' \
-  --mcp-servers '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch@2025.4.7"]}' \
-  --mcp-servers '{"name": "context7", "command": "npx", "args": ["-y", "@upstash/context7-mcp@1.0.14"], "env": []}' \
-  --mcp-servers '{"name": "tavily", "command": "npx", "args": ["-y", "tavily-mcp@0.2.9"], "env": ["TAVILY_API_KEY"]}'
+  --mcp-servers '{"name": "filesystem", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "{home_directory}"]}' \
+  --mcp-servers '{"name": "fetch", "command": "uvx", "args": ["mcp-server-fetch"]}' \
+  --mcp-servers '{"name": "context7", "command": "npx", "args": ["-y", "@upstash/context7-mcp"], "env": []}' \
+  --mcp-servers '{"name": "tavily", "command": "npx", "args": ["-y", "tavily-mcp"], "env": ["TAVILY_API_KEY"]}'
 ```
 
 Notes:
 - Model names are routed via LiteLLM. Use any provider/model you have keys for; set the corresponding API key env vars.
-- The `--mcp-servers` values are JSON strings; see below for details.
+- The `--mcp-servers` values are JSON strings; arguments support variable substitution for `{home_directory}` and `{working_directory}`.
 
 ## Usage Highlights
 
@@ -95,7 +95,6 @@ Notes:
 - `--print-chunks`/`--print-reasoning` Control live stream and reasoning display in the TUI.
 - `--shell-confirmation-patterns` Ask for confirmation before running matching shell commands.
 - `--tool-confirmation-patterns` Ask for confirmation before running matching tools.
-- `--no-truncate-tools` List of regex patterns for tools whose output should not be truncated.
 - `--wait-for-debugger` Wait for a debugger (debugpy) to attach on port 1234.
 
 Run `coding-assistant --help` to see all options.
@@ -113,10 +112,10 @@ Pass MCP servers with repeated `--mcp-servers` flags as JSON strings:
 ```
 
 The `run.fish` script includes these examples:
-- filesystem: `@modelcontextprotocol/server-filesystem@2025.7.29`
-- fetch: `mcp-server-fetch@2025.4.7` (via `uvx`)
-- context7: `@upstash/context7-mcp@1.0.14`
-- tavily: `tavily-mcp@0.2.9` (needs `TAVILY_API_KEY`)
+- filesystem: `@modelcontextprotocol/server-filesystem`
+- fetch: `mcp-server-fetch` (via `uvx`)
+- context7: `@upstash/context7-mcp`
+- tavily: `tavily-mcp` (needs `TAVILY_API_KEY`)
 
 You can print discovered tools from running MCP servers:
 
@@ -141,6 +140,13 @@ Use these flags to widen access if needed when working across multiple directori
 ## Tracing (optional)
 
 If `--trace-endpoint` is reachable (default `http://localhost:4318/v1/traces`), OTLP traces are exported using the HTTP exporter. If unreachable, tracing is disabled automatically.
+
+## Shell command execution behavior
+
+The `execute_shell_command` tool:
+- Merges stderr into stdout and returns plain text (no JSON envelope).
+- Prefixes output with `Returncode: N` only when the command exits non-zero.
+- Supports `truncate_at` to limit the combined output size and appends a note when truncation occurs.
 
 ## Development
 

--- a/src/coding_assistant/agents/callbacks.py
+++ b/src/coding_assistant/agents/callbacks.py
@@ -148,7 +148,7 @@ class RichCallbacks(AgentCallbacks):
         except json.JSONDecodeError:
             return None
 
-    def _format_tool_result(self, result: str, tool_name: str):
+    def _format_tool_result(self, result: str):
         if data := self._try_parse_json(result):
             return Pretty(data, expand_all=True, indent_size=2)
         else:
@@ -160,7 +160,7 @@ class RichCallbacks(AgentCallbacks):
         if arguments is not None:
             parts.append(Padding(Pretty(arguments, expand_all=True, indent_size=2), (1, 0, 0, 0)))
 
-        parts.append(Padding(self._format_tool_result(result, tool_name), (1, 0, 0, 0)))
+        parts.append(Padding(self._format_tool_result(result), (1, 0, 0, 0)))
 
         render_group = Group(*parts)
         print(

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -191,8 +191,6 @@ async def handle_tool_calls(
     ui: UI,
 ):
     tool_calls = message.tool_calls
-    trace.get_current_span().set_attribute("message.tool_calls", tool_calls)
-
     if not tool_calls:
         append_user_message(
             agent.history,
@@ -201,6 +199,8 @@ async def handle_tool_calls(
             "I detected a step from you without any tool calls. This is not allowed. If you want to ask the client something, please use the `ask_user` tool. If you are done with your task, please call the `finish_task` tool to signal that you are done. Otherwise, continue your work.",
         )
         return
+
+    trace.get_current_span().set_attribute("message.tool_calls", [x.model_dump_json() for x in tool_calls])
 
     aws = []
     for tool_call in tool_calls:

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -21,6 +21,14 @@ class FakeToolCall:
     id: str
     function: FakeFunction
 
+    def model_dump_json(self) -> str:
+        return json.dumps(
+            {
+                "id": self.id,
+                "function": {"name": self.function.name, "arguments": self.function.arguments},
+            }
+        )
+
 
 class FakeMessage:
     def __init__(

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -13,7 +13,7 @@ from coding_assistant.ui import UI
 @dataclass
 class FakeFunction:
     name: str
-    arguments: str = "{}"
+    arguments: str
 
 
 @dataclass

--- a/src/coding_assistant/instructions.py
+++ b/src/coding_assistant/instructions.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 INSTRUCTIONS = """
 - Do not initialize a new git repository, unless your client explicitly requests it.
@@ -44,7 +43,7 @@ PLANNING_INSTRUCTIONS = """
 """.strip()
 
 
-def get_instructions(working_directory: Path, plan: bool, user_instructions: List[str]) -> str:
+def get_instructions(working_directory: Path, plan: bool, user_instructions: list[str]) -> str:
     instructions = INSTRUCTIONS.strip()
 
     if plan:

--- a/src/coding_assistant/main.py
+++ b/src/coding_assistant/main.py
@@ -5,7 +5,6 @@ import os
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, BooleanOptionalAction
 from pathlib import Path
-from typing import Optional
 
 import debugpy
 import requests

--- a/src/coding_assistant/sandbox.py
+++ b/src/coding_assistant/sandbox.py
@@ -2,7 +2,6 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
 
 from landlock import FSAccess, Ruleset
 

--- a/src/coding_assistant/tools/mcp.py
+++ b/src/coding_assistant/tools/mcp.py
@@ -3,7 +3,7 @@ import os
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncGenerator, Dict, List, Set
+from typing import AsyncGenerator
 
 import mcp
 from mcp import ClientSession, StdioServerParameters
@@ -64,7 +64,7 @@ class MCPWrappedTool(Tool):
 
 
 async def get_mcp_wrapped_tools(mcp_servers: list[MCPServer]) -> list[Tool]:
-    wrapped: List = []
+    wrapped: list[Tool] = []
     for server in mcp_servers:
         tools_response = await server.session.list_tools()
         for remote_tool in getattr(tools_response, "tools"):
@@ -89,7 +89,7 @@ def get_default_env():
 
 @asynccontextmanager
 async def _get_mcp_server(
-    name: str, command: str, args: List[str], env: dict[str, str] | None = None
+    name: str, command: str, args: list[str], env: dict[str, str] | None = None
 ) -> AsyncGenerator[MCPServer, None]:
     logger.info(f"Starting MCP server '{name}' with command '{command}', args '{' '.join(args)}' and env: '{env}'")
     params = StdioServerParameters(command=command, args=args, env=env)
@@ -106,14 +106,14 @@ async def _get_mcp_server(
 
 @asynccontextmanager
 async def get_mcp_servers_from_config(
-    config_servers: List[MCPServerConfig], working_directory: Path
-) -> AsyncGenerator[List[MCPServer], None]:
+    config_servers: list[MCPServerConfig], working_directory: Path
+) -> AsyncGenerator[list[MCPServer], None]:
     """Create MCP servers from configuration objects."""
     if not working_directory.exists():
         raise ValueError(f"Working directory {working_directory} does not exist.")
 
     async with AsyncExitStack() as stack:
-        servers: List[MCPServer] = []
+        servers: list[MCPServer] = []
 
         for server_config in config_servers:
             # Format all arguments with available variables

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -262,9 +262,9 @@ class ExecuteShellCommandTool(Tool):
         else:
             result = stdout.decode()
 
-        if truncate_at is not None and len(result) > truncate_at:
-            truncated = result[: max(0, truncate_at - 200)]
+        if len(result) > truncate_at:
             note = "\n\n[truncated output due to truncate_at limit]"
+            truncated = result[: max(0, truncate_at - len(note))]
             result = truncated + note
 
         return TextResult(content=result)

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import re
-from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class LaunchOrchestratorAgentSchema(BaseModel):
     task: str = Field(description="The task to assign to the orchestrator agent.")
-    summaries: List[str] = Field(
+    summaries: list[str] = Field(
         default_factory=list,
         description="The past conversation summaries of the client and the agent.",
     )
@@ -215,7 +214,7 @@ class ExecuteShellCommandSchema(BaseModel):
 class ExecuteShellCommandTool(Tool):
     def __init__(
         self,
-        shell_confirmation_patterns: Optional[List[str]] = None,
+        shell_confirmation_patterns: list[str] | None = None,
         ui: UI | None = None,
     ):
         self._shell_confirmation_patterns = shell_confirmation_patterns or []

--- a/src/coding_assistant/ui.py
+++ b/src/coding_assistant/ui.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import logging
-from typing import Optional
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.shortcuts import create_confirm_session
@@ -10,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class UI(ABC):
     @abstractmethod
-    async def ask(self, prompt_text: str, default: Optional[str] = None) -> str:
+    async def ask(self, prompt_text: str, default: str | None = None) -> str:
         pass
 
     @abstractmethod
@@ -19,7 +18,7 @@ class UI(ABC):
 
 
 class PromptToolkitUI(UI):
-    async def ask(self, prompt_text: str, default: Optional[str] = None) -> str:
+    async def ask(self, prompt_text: str, default: str | None = None) -> str:
         print(prompt_text)
         return await PromptSession().prompt_async("> ", default=default or "")
 
@@ -28,7 +27,7 @@ class PromptToolkitUI(UI):
 
 
 class DefaultAnswerUI(UI):
-    async def ask(self, prompt_text: str, default: Optional[str] = None) -> str:
+    async def ask(self, prompt_text: str, default: str | None = None) -> str:
         logger.info(f"Skipping user input for prompt: {prompt_text}")
         return default or "UI is not available."
 
@@ -38,7 +37,7 @@ class DefaultAnswerUI(UI):
 
 
 class NullUI(UI):
-    async def ask(self, prompt_text: str, default: Optional[str] = None) -> str:
+    async def ask(self, prompt_text: str, default: str | None = None) -> str:
         raise RuntimeError("No UI available")
 
     async def confirm(self, prompt_text: str) -> bool:


### PR DESCRIPTION
Summary

This PR refines tracing, shell command output handling, typing consistency, and documentation.

What changed

- Tracing
  - Serialize tool call metadata as JSON strings to avoid Pydantic serialization issues in spans.
  - Ensure function.args and function.result are trace-friendly.
- Shell command execution
  - ExecuteShellCommandTool: append a truncation note and compute slice based on the note length; keep plain text output; include Returncode: N prefix only on non-zero exits; stderr merged into stdout.
- Callbacks
  - RichCallbacks._format_tool_result now infers JSON automatically from result content without needing tool_name.
- Typing consistency (no behavior change)
  - Prefer built-in generics (list[str], dict[str, str]) and PEP 604 unions (X | None) in touched modules.
- Documentation
  - README: remove --no-truncate-tools flag; refresh MCP examples; mention home_directory formatting; clarify ExecuteShellCommand behavior and truncation.

Motivation

- Make OTLP traces stable across environments and pydantic versions.
- Make shell output predictable and safe by clearly signaling truncation and non-zero exits.
- Improve developer experience by keeping typing modern and consistent in edited files.
- Keep docs aligned with actual behavior and run.fish defaults.

Testing

- just test: 84 passed (pytest-xdist), with the known non-blocking PytestUnraisableExceptionWarning during teardown.
- Manual checks: rg for truncate_at logic and README references.

Follow-ups (separate PRs welcome)

- Broader typing/style pass across the repository (mypy/ruff settings, if desired).
- Add a docs section on tracing: how to visualize spans, notable attributes.
- Consider documenting sandbox defaults and how to widen access safely.
