### PR TITLE
Agent API split: introduce AgentDescription/AgentState/Context; update tools/tests; stricter tool-call arg handling

### DIFF
--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -14,14 +14,14 @@ from coding_assistant.agents.history import append_assistant_message, append_too
 from coding_assistant.agents.interrupts import InterruptibleSection, NonInterruptibleSection
 from coding_assistant.agents.parameters import Parameter, format_parameters
 from coding_assistant.agents.types import (
-    AgentDescription,
-    AgentState,
     AgentContext,
+    AgentDescription,
+    AgentOutput,
+    AgentState,
     Completer,
     FinishTaskResult,
     ShortenConversationResult,
     TextResult,
-    AgentOutput,
 )
 from coding_assistant.llm.adapters import execute_tool_call, get_tools
 from coding_assistant.ui import UI
@@ -357,5 +357,3 @@ async def run_agent_loop(
             break
 
     assert state.output is not None
-
-    return AgentOutput(result=state.output.result, summary=state.output.summary)

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -12,7 +12,7 @@ from opentelemetry import trace
 from coding_assistant.agents.callbacks import AgentCallbacks
 from coding_assistant.agents.history import append_assistant_message, append_tool_message, append_user_message
 from coding_assistant.agents.interrupts import InterruptibleSection, NonInterruptibleSection
-from coding_assistant.agents.parameters import format_parameters
+from coding_assistant.agents.parameters import format_parameters, Parameter
 from coding_assistant.agents.types import (
     Agent,
     AgentOutput,
@@ -30,12 +30,6 @@ tracer = trace.get_tracer(__name__)
 
 START_MESSAGE_TEMPLATE = """
 You are an agent named `{name}`.
-
-## Task
-
-Your client has been given the following description of your work and capabilities: 
-
-{description}
 
 ## Parameters
 
@@ -58,7 +52,6 @@ def _create_start_message(agent: Agent) -> str:
     parameters_str = format_parameters(agent.parameters)
     message = START_MESSAGE_TEMPLATE.format(
         name=agent.name,
-        description=textwrap.indent(agent.description, "> "),
         parameters=parameters_str,
     )
 

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -6,13 +6,12 @@ import re
 import textwrap
 from json import JSONDecodeError
 
-import litellm
 from opentelemetry import trace
 
 from coding_assistant.agents.callbacks import AgentCallbacks
 from coding_assistant.agents.history import append_assistant_message, append_tool_message, append_user_message
 from coding_assistant.agents.interrupts import InterruptibleSection, NonInterruptibleSection
-from coding_assistant.agents.parameters import Parameter, format_parameters
+from coding_assistant.agents.parameters import format_parameters
 from coding_assistant.agents.types import (
     AgentContext,
     AgentDescription,

--- a/src/coding_assistant/agents/execution.py
+++ b/src/coding_assistant/agents/execution.py
@@ -12,10 +12,11 @@ from opentelemetry import trace
 from coding_assistant.agents.callbacks import AgentCallbacks
 from coding_assistant.agents.history import append_assistant_message, append_tool_message, append_user_message
 from coding_assistant.agents.interrupts import InterruptibleSection, NonInterruptibleSection
-from coding_assistant.agents.parameters import format_parameters, Parameter
+from coding_assistant.agents.parameters import Parameter, format_parameters
 from coding_assistant.agents.types import (
-    Agent,
+    AgentDescription,
     AgentOutput,
+    AgentState,
     Completer,
     FinishTaskResult,
     ShortenConversationResult,
@@ -48,18 +49,18 @@ Afterwards, call the `finish_task` tool again to signal that you are done.
 """.strip()
 
 
-def _create_start_message(agent: Agent) -> str:
-    parameters_str = format_parameters(agent.parameters)
+def _create_start_message(desc: AgentDescription) -> str:
+    parameters_str = format_parameters(desc.parameters)
     message = START_MESSAGE_TEMPLATE.format(
-        name=agent.name,
+        name=desc.name,
         parameters=parameters_str,
     )
 
     return message
 
 
-def _handle_finish_task_result(result: FinishTaskResult, agent: Agent):
-    agent.output = AgentOutput(
+def _handle_finish_task_result(result: FinishTaskResult, state: AgentState):
+    state.output = AgentOutput(
         result=result.result,
         summary=result.summary,
     )
@@ -71,20 +72,20 @@ def _handle_text_result(result: TextResult) -> str:
 
 
 def _handle_shorten_conversation_result(
-    result: ShortenConversationResult, agent: Agent, agent_callbacks: AgentCallbacks
+    result: ShortenConversationResult, desc: AgentDescription, state: AgentState, agent_callbacks: AgentCallbacks
 ):
-    start_message = _create_start_message(agent)
-    agent.history = []
+    start_message = _create_start_message(desc)
+    state.history = []
     append_user_message(
-        agent.history,
+        state.history,
         agent_callbacks,
-        agent.name,
+        desc.name,
         start_message,
     )
     append_user_message(
-        agent.history,
+        state.history,
         agent_callbacks,
-        agent.name,
+        desc.name,
         f"A summary of your conversation with the client until now:\n\n{result.summary}\n\nPlease continue your work.",
     )
     return "Conversation shortened and history reset."
@@ -93,7 +94,8 @@ def _handle_shorten_conversation_result(
 @tracer.start_as_current_span("handle_tool_call")
 async def handle_tool_call(
     tool_call: litellm.ChatCompletionMessageToolCall,
-    agent: Agent,
+    desc: AgentDescription,
+    state: AgentState,
     agent_callbacks: AgentCallbacks,
     tool_confirmation_patterns: list[str],
     *,
@@ -109,12 +111,12 @@ async def handle_tool_call(
         function_args = json.loads(args_str)
     except JSONDecodeError as e:
         logger.error(
-            f"[{agent.name}] [{tool_call.id}] Failed to parse tool '{function_name}' arguments as JSON: {e} | raw: {args_str}"
+            f"[{desc.name}] [{tool_call.id}] Failed to parse tool '{function_name}' arguments as JSON: {e} | raw: {args_str}"
         )
         append_tool_message(
-            agent.history,
+            state.history,
             agent_callbacks,
-            agent.name,
+            desc.name,
             tool_call.id,
             function_name,
             None,
@@ -128,9 +130,9 @@ async def handle_tool_call(
             answer = await ui.confirm(question)
             if not answer:
                 append_tool_message(
-                    agent.history,
+                    state.history,
                     agent_callbacks,
-                    agent.name,
+                    desc.name,
                     tool_call.id,
                     function_name,
                     function_args,
@@ -141,15 +143,15 @@ async def handle_tool_call(
     trace.get_current_span().set_attribute("function.name", function_name)
     trace.get_current_span().set_attribute("function.args", json.dumps(function_args))
 
-    logger.info(f"[{tool_call.id}] [{agent.name}] Calling tool '{function_name}' with arguments {function_args}")
+    logger.info(f"[{tool_call.id}] [{desc.name}] Calling tool '{function_name}' with arguments {function_args}")
 
     try:
-        function_call_result = await execute_tool_call(function_name, function_args, agent.tools)
+        function_call_result = await execute_tool_call(function_name, function_args, desc.tools)
     except ValueError as e:
         append_tool_message(
-            agent.history,
+            state.history,
             agent_callbacks,
-            agent.name,
+            desc.name,
             tool_call.id,
             function_name,
             function_args,
@@ -160,17 +162,17 @@ async def handle_tool_call(
     trace.get_current_span().set_attribute("function.result", str(function_call_result))
 
     result_handlers = {
-        FinishTaskResult: lambda r: _handle_finish_task_result(r, agent),
-        ShortenConversationResult: lambda r: _handle_shorten_conversation_result(r, agent, agent_callbacks),
+        FinishTaskResult: lambda r: _handle_finish_task_result(r, state),
+        ShortenConversationResult: lambda r: _handle_shorten_conversation_result(r, desc, state, agent_callbacks),
         TextResult: lambda r: _handle_text_result(r),
     }
 
     tool_return_summary = result_handlers[type(function_call_result)](function_call_result)
 
     append_tool_message(
-        agent.history,
+        state.history,
         agent_callbacks,
-        agent.name,
+        desc.name,
         tool_call.id,
         function_name,
         function_args,
@@ -181,7 +183,8 @@ async def handle_tool_call(
 @tracer.start_as_current_span("handle_tool_calls")
 async def handle_tool_calls(
     message: litellm.Message,
-    agent: Agent,
+    desc: AgentDescription,
+    state: AgentState,
     agent_callbacks: AgentCallbacks,
     tool_confirmation_patterns: list[str],
     *,
@@ -190,9 +193,9 @@ async def handle_tool_calls(
     tool_calls = message.tool_calls
     if not tool_calls:
         append_user_message(
-            agent.history,
+            state.history,
             agent_callbacks,
-            agent.name,
+            desc.name,
             "I detected a step from you without any tool calls. This is not allowed. If you want to ask the client something, please use the `ask_user` tool. If you are done with your task, please call the `finish_task` tool to signal that you are done. Otherwise, continue your work.",
         )
         return
@@ -204,7 +207,8 @@ async def handle_tool_calls(
         task = asyncio.create_task(
             handle_tool_call(
                 tool_call,
-                agent,
+                desc,
+                state,
                 agent_callbacks,
                 tool_confirmation_patterns,
                 ui=ui,
@@ -226,7 +230,8 @@ async def handle_tool_calls(
 
 @tracer.start_as_current_span("do_single_step")
 async def do_single_step(
-    agent: Agent,
+    desc: AgentDescription,
+    state: AgentState,
     agent_callbacks: AgentCallbacks,
     shorten_conversation_at_tokens: int,
     *,
@@ -234,24 +239,24 @@ async def do_single_step(
     ui: UI,
     tool_confirmation_patterns: list[str],
 ):
-    trace.get_current_span().set_attribute("agent.name", agent.name)
+    trace.get_current_span().set_attribute("agent.name", desc.name)
 
     # Validate agent tools
-    if not any(tool.name() == "finish_task" for tool in agent.tools):
+    if not any(tool.name() == "finish_task" for tool in desc.tools):
         raise RuntimeError("Agent needs to have a `finish_task` tool in order to run a step.")
-    if not any(tool.name() == "shorten_conversation" for tool in agent.tools):
+    if not any(tool.name() == "shorten_conversation" for tool in desc.tools):
         raise RuntimeError("Agent needs to have a `shorten_conversation` tool in order to run a step.")
 
-    tools = await get_tools(agent.tools)
+    tools = await get_tools(desc.tools)
     trace.get_current_span().set_attribute("agent.tools", json.dumps(tools))
 
-    if not agent.history:
+    if not state.history:
         raise RuntimeError("Agent needs to have history in order to run a step.")
-    trace.get_current_span().set_attribute("agent.history", json.dumps(agent.history))
+    trace.get_current_span().set_attribute("agent.history", json.dumps(state.history))
 
     completion = await completer(
-        agent.history,
-        model=agent.model,
+        state.history,
+        model=desc.model,
         tools=tools,
         callbacks=agent_callbacks,
     )
@@ -260,15 +265,16 @@ async def do_single_step(
 
     if hasattr(message, "reasoning_content") and message.reasoning_content:
         trace.get_current_span().set_attribute("completion.reasoning_content", message.reasoning_content)
-        agent_callbacks.on_assistant_reasoning(agent.name, message.reasoning_content)
+        agent_callbacks.on_assistant_reasoning(desc.name, message.reasoning_content)
 
         # We delete reasoning so we don't store it in the history, and hence do not send it to the LLM again.
         del message.reasoning_content
 
-    append_assistant_message(agent.history, agent_callbacks, agent.name, message)
+    append_assistant_message(state.history, agent_callbacks, desc.name, message)
     await handle_tool_calls(
         message,
-        agent,
+        desc,
+        state,
         agent_callbacks,
         tool_confirmation_patterns,
         ui=ui,
@@ -277,9 +283,9 @@ async def do_single_step(
     # Check conversation length and request shortening if needed
     if completion.tokens > shorten_conversation_at_tokens:
         append_user_message(
-            agent.history,
+            state.history,
             agent_callbacks,
-            agent.name,
+            desc.name,
             "Your conversation history has grown too large. Please summarize it by using the `shorten_conversation` tool.",
         )
 
@@ -288,7 +294,8 @@ async def do_single_step(
 
 @tracer.start_as_current_span("run_agent_loop")
 async def run_agent_loop(
-    agent: Agent,
+    desc: AgentDescription,
+    state: AgentState,
     agent_callbacks: AgentCallbacks,
     *,
     completer: Completer,
@@ -298,23 +305,24 @@ async def run_agent_loop(
     enable_user_feedback: bool = False,
     is_interruptible: bool = False,
 ) -> AgentOutput:
-    if agent.output:
+    if state.output:
         raise RuntimeError("Agent already has a result or summary.")
 
-    trace.get_current_span().set_attribute("agent.name", agent.name)
-    parameters_json = json.dumps([dataclasses.asdict(p) for p in agent.parameters])
+    trace.get_current_span().set_attribute("agent.name", desc.name)
+    parameters_json = json.dumps([dataclasses.asdict(p) for p in desc.parameters])
     trace.get_current_span().set_attribute("agent.parameter_description", parameters_json)
 
-    start_message = _create_start_message(agent)
-    agent_callbacks.on_agent_start(agent.name, agent.model, is_resuming=bool(agent.history))
-    append_user_message(agent.history, agent_callbacks, agent.name, start_message)
+    start_message = _create_start_message(desc)
+    agent_callbacks.on_agent_start(desc.name, desc.model, is_resuming=bool(state.history))
+    append_user_message(state.history, agent_callbacks, desc.name, start_message)
 
     while True:
-        while not agent.output:
+        while not state.output:
             section_cls = InterruptibleSection if is_interruptible else NonInterruptibleSection
             with section_cls() as interruptible_section:
                 await do_single_step(
-                    agent,
+                    desc,
+                    state,
                     agent_callbacks,
                     shorten_conversation_at_tokens,
                     completer=completer,
@@ -323,26 +331,26 @@ async def run_agent_loop(
                 )
 
             if interruptible_section.was_interrupted:
-                logger.info(f"Agent '{agent.name}' was interrupted during execution.")
+                logger.info(f"Agent '{desc.name}' was interrupted during execution.")
                 feedback = await ui.ask("Feedback: ")
                 formatted_feedback = FEEDBACK_TEMPLATE.format(
                     feedback=textwrap.indent(feedback, "> "),
                 )
-                append_user_message(agent.history, agent_callbacks, agent.name, formatted_feedback)
+                append_user_message(state.history, agent_callbacks, desc.name, formatted_feedback)
 
-        trace.get_current_span().set_attribute("agent.result", agent.output.result)
-        trace.get_current_span().set_attribute("agent.summary", agent.output.summary)
-        agent_callbacks.on_agent_end(agent.name, agent.output.result, agent.output.summary)
+        trace.get_current_span().set_attribute("agent.result", state.output.result)
+        trace.get_current_span().set_attribute("agent.summary", state.output.summary)
+        agent_callbacks.on_agent_end(desc.name, state.output.result, state.output.summary)
 
         user_feedback: str = "Ok"
         if enable_user_feedback:
-            user_feedback = await ui.ask(f"Feedback for {agent.name}", default="Ok")
+            user_feedback = await ui.ask(f"Feedback for {desc.name}", default="Ok")
 
         if user_feedback != "Ok":
             formatted_feedback = FEEDBACK_TEMPLATE.format(feedback=textwrap.indent(user_feedback, "> "))
-            append_user_message(agent.history, agent_callbacks, agent.name, formatted_feedback)
-            agent.output = None  # continue loop
+            append_user_message(state.history, agent_callbacks, desc.name, formatted_feedback)
+            state.output = None  # continue loop
         else:
             break
 
-    return agent.output
+    return state.output

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -4,7 +4,7 @@ from typing import Iterable, Sequence
 from unittest.mock import AsyncMock, Mock
 
 from coding_assistant.agents.parameters import Parameter
-from coding_assistant.agents.types import AgentDescription, AgentState, Tool
+from coding_assistant.agents.types import AgentDescription, AgentState, AgentContext, Tool
 from coding_assistant.llm.model import Completion
 from coding_assistant.tools.mcp import MCPServer
 from coding_assistant.ui import UI
@@ -138,3 +138,20 @@ def make_test_agent(
     )
     state = AgentState(history=list(history) if history is not None else [])
     return desc, state
+
+def make_test_context(
+    *,
+    name: str = "TestAgent",
+    model: str = "TestMode",
+    parameters: Sequence[Parameter] | None = None,
+    tools: Iterable[Tool] | None = None,
+    history: list[dict] | None = None,
+) -> AgentContext:
+    desc, state = make_test_agent(
+        name=name,
+        model=model,
+        parameters=parameters,
+        tools=tools,
+        history=history,
+    )
+    return AgentContext(desc=desc, state=state)

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -126,7 +126,6 @@ def make_test_agent(
     *,
     name: str = "TestAgent",
     model: str = "TestMode",
-    description: str = "TestDescription",
     parameters: Sequence[Parameter] | None = None,
     tools: Iterable[Tool] | None = None,
     history: list[dict] | None = None,
@@ -134,7 +133,6 @@ def make_test_agent(
     return Agent(
         name=name,
         model=model,
-        description=description,
         parameters=list(parameters) if parameters is not None else [],
         tools=list(tools) if tools is not None else [],
         history=list(history) if history is not None else [],

--- a/src/coding_assistant/agents/tests/helpers.py
+++ b/src/coding_assistant/agents/tests/helpers.py
@@ -4,7 +4,7 @@ from typing import Iterable, Sequence
 from unittest.mock import AsyncMock, Mock
 
 from coding_assistant.agents.parameters import Parameter
-from coding_assistant.agents.types import Agent, Tool
+from coding_assistant.agents.types import AgentDescription, AgentState, Tool
 from coding_assistant.llm.model import Completion
 from coding_assistant.tools.mcp import MCPServer
 from coding_assistant.ui import UI
@@ -129,11 +129,12 @@ def make_test_agent(
     parameters: Sequence[Parameter] | None = None,
     tools: Iterable[Tool] | None = None,
     history: list[dict] | None = None,
-) -> Agent:
-    return Agent(
+):
+    desc = AgentDescription(
         name=name,
         model=model,
         parameters=list(parameters) if parameters is not None else [],
         tools=list(tools) if tools is not None else [],
-        history=list(history) if history is not None else [],
     )
+    state = AgentState(history=list(history) if history is not None else [])
+    return desc, state

--- a/src/coding_assistant/agents/tests/test_callbacks_integration.py
+++ b/src/coding_assistant/agents/tests/test_callbacks_integration.py
@@ -12,7 +12,7 @@ from coding_assistant.agents.tests.helpers import (
     make_test_agent,
     make_ui_mock,
 )
-from coding_assistant.agents.types import TextResult, Tool
+from coding_assistant.agents.types import TextResult, Tool, AgentContext
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
 
 
@@ -31,8 +31,7 @@ async def test_on_agent_start_end_called_with_expected_args():
     desc, state = make_test_agent(tools=[FinishTaskTool(), ShortenConversation()])
 
     await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         callbacks,
         shorten_conversation_at_tokens=200_000,
         tool_confirmation_patterns=[],
@@ -54,8 +53,7 @@ async def test_on_tool_message_called_with_arguments_and_result():
     desc, state = make_test_agent(tools=[EchoTool(), FinishTaskTool(), ShortenConversation()])
 
     await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         callbacks,
         shorten_conversation_at_tokens=200_000,
         tool_confirmation_patterns=[],

--- a/src/coding_assistant/agents/tests/test_execution_shorten_conversation.py
+++ b/src/coding_assistant/agents/tests/test_execution_shorten_conversation.py
@@ -10,8 +10,10 @@ from coding_assistant.agents.tests.helpers import (
     FakeToolCall,
     FakeCompleter,
     make_test_agent,
+    make_test_context,
     make_ui_mock,
 )
+from coding_assistant.agents.types import AgentContext
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
 
 
@@ -38,7 +40,8 @@ async def test_shorten_conversation_resets_history():
         ),
     )
 
-    await handle_tool_call(tool_call, desc, state, callbacks, tool_confirmation_patterns=[], ui=make_ui_mock())
+    ctx = AgentContext(desc=desc, state=state)
+    await handle_tool_call(tool_call, ctx, callbacks, tool_confirmation_patterns=[], ui=make_ui_mock())
 
     # History should be reset to a fresh start message + summary message, followed by the tool result message
     assert len(state.history) >= 3
@@ -73,8 +76,7 @@ async def test_shorten_conversation_resets_history():
     completer = FakeCompleter([FakeMessage(tool_calls=[finish_call])])
 
     await do_single_step(
-        desc,
-        state,
+        ctx,
         callbacks,
         shorten_conversation_at_tokens=200_000,
         completer=completer,

--- a/src/coding_assistant/agents/tests/test_model_contract.py
+++ b/src/coding_assistant/agents/tests/test_model_contract.py
@@ -13,7 +13,7 @@ from coding_assistant.agents.tests.helpers import (
     make_test_agent,
     make_ui_mock,
 )
-from coding_assistant.agents.types import Agent, TextResult, Tool
+from coding_assistant.agents.types import AgentDescription, AgentState, TextResult, Tool
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
 
 
@@ -38,12 +38,13 @@ async def test_do_single_step_adds_shorten_prompt_on_token_threshold():
     fake_message = FakeMessage(content=("h" * 2000), tool_calls=[tool_call])
     completer = FakeCompleter([fake_message])
 
-    agent = make_test_agent(
+    desc, state = make_test_agent(
         tools=[DummyTool(), FinishTaskTool(), ShortenConversation()], history=[{"role": "user", "content": "start"}]
     )
 
     msg = await do_single_step(
-        agent,
+        desc,
+        state,
         NullCallbacks(),
         shorten_conversation_at_tokens=1000,
         completer=completer,
@@ -80,7 +81,7 @@ async def test_do_single_step_adds_shorten_prompt_on_token_threshold():
         },
     ]
 
-    assert agent.history == expected_history
+    assert state.history == expected_history
 
 
 @pytest.mark.asyncio
@@ -92,7 +93,7 @@ async def test_reasoning_is_forwarded_and_not_stored():
 
     completer = FakeCompleter([msg])
 
-    agent = make_test_agent(
+    desc, state = make_test_agent(
         tools=[DummyTool(), FinishTaskTool(), ShortenConversation()],
         history=[{"role": "user", "content": "start"}],
     )
@@ -100,7 +101,8 @@ async def test_reasoning_is_forwarded_and_not_stored():
     callbacks = Mock(spec=AgentCallbacks)
 
     await do_single_step(
-        agent,
+        desc,
+        state,
         callbacks,
         shorten_conversation_at_tokens=100_000,
         completer=completer,
@@ -109,10 +111,10 @@ async def test_reasoning_is_forwarded_and_not_stored():
     )
 
     # Assert reasoning was forwarded via callback
-    callbacks.on_assistant_reasoning.assert_called_once_with(agent.name, "These are my private thoughts")
+    callbacks.on_assistant_reasoning.assert_called_once_with(desc.name, "These are my private thoughts")
 
     # Assert reasoning is not stored in history anywhere
-    for entry in agent.history:
+    for entry in state.history:
         assert "reasoning_content" not in entry
 
 
@@ -122,13 +124,14 @@ async def test_reasoning_is_forwarded_and_not_stored():
 @pytest.mark.asyncio
 async def test_requires_finish_tool():
     # Missing finish_task tool should raise
-    agent = make_test_agent(
+    desc, state = make_test_agent(
         tools=[DummyTool(), ShortenConversation()],
         history=[{"role": "user", "content": "start"}],
     )
     with pytest.raises(RuntimeError, match="Agent needs to have a `finish_task` tool in order to run a step."):
         await do_single_step(
-            agent,
+            desc,
+            state,
             NullCallbacks(),
             shorten_conversation_at_tokens=1000,
             completer=FakeCompleter([FakeMessage(content="hi")]),
@@ -140,13 +143,14 @@ async def test_requires_finish_tool():
 @pytest.mark.asyncio
 async def test_requires_shorten_tool():
     # Missing shorten_conversation tool should raise
-    agent = make_test_agent(
+    desc, state = make_test_agent(
         tools=[DummyTool(), FinishTaskTool()],
         history=[{"role": "user", "content": "start"}],
     )
     with pytest.raises(RuntimeError, match="Agent needs to have a `shorten_conversation` tool in order to run a step."):
         await do_single_step(
-            agent,
+            desc,
+            state,
             NullCallbacks(),
             shorten_conversation_at_tokens=1000,
             completer=FakeCompleter([FakeMessage(content="hi")]),
@@ -158,10 +162,11 @@ async def test_requires_shorten_tool():
 @pytest.mark.asyncio
 async def test_requires_non_empty_history():
     # Empty history should raise
-    agent = make_test_agent(tools=[DummyTool(), FinishTaskTool(), ShortenConversation()], history=[])
+    desc, state = make_test_agent(tools=[DummyTool(), FinishTaskTool(), ShortenConversation()], history=[])
     with pytest.raises(RuntimeError, match="Agent needs to have history in order to run a step."):
         await do_single_step(
-            agent,
+            desc,
+            state,
             NullCallbacks(),
             shorten_conversation_at_tokens=1000,
             completer=FakeCompleter([FakeMessage(content="hi")]),

--- a/src/coding_assistant/agents/tests/test_run_loop_slices.py
+++ b/src/coding_assistant/agents/tests/test_run_loop_slices.py
@@ -12,7 +12,7 @@ from coding_assistant.agents.tests.helpers import (
     make_test_agent,
     make_ui_mock,
 )
-from coding_assistant.agents.types import AgentDescription, AgentState, TextResult, Tool
+from coding_assistant.agents.types import AgentDescription, AgentState, AgentContext, TextResult, Tool
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
 
 
@@ -57,8 +57,7 @@ async def test_tool_selection_then_finish():
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=False,
@@ -133,8 +132,7 @@ async def test_unknown_tool_error_then_finish(monkeypatch):
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=False,
@@ -204,8 +202,7 @@ async def test_assistant_message_without_tool_calls_prompts_correction(monkeypat
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=False,
@@ -295,8 +292,7 @@ async def test_interrupt_feedback_injected_and_loop_continues(monkeypatch):
     )
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=False,
@@ -344,8 +340,7 @@ async def test_interrupt_feedback_injected_and_loop_continues(monkeypatch):
         agent = make_test_agent(tools=[FinishTaskTool(), ShortenConversation()])
 
         output = await run_agent_loop(
-        desc,
-        state,
+            AgentContext(desc=desc, state=state),
             NullCallbacks(),
             shorten_conversation_at_tokens=200_000,
             enable_user_feedback=False,
@@ -368,8 +363,7 @@ async def test_errors_if_output_already_set():
     state.summary = "s"
     with pytest.raises(RuntimeError, match="Agent already has a result or summary."):
         await run_agent_loop(
-            desc,
-            state,
+            AgentContext(desc=desc, state=state),
             NullCallbacks(),
             shorten_conversation_at_tokens=200_000,
             enable_user_feedback=False,
@@ -393,8 +387,7 @@ async def test_feedback_ok_does_not_reloop():
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=True,
@@ -429,8 +422,7 @@ async def test_multiple_tool_calls_processed_in_order():
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=False,
@@ -526,8 +518,7 @@ async def test_feedback_loop_then_finish():
     desc, state = agent
 
     output_state = await run_agent_loop(
-        desc,
-        state,
+        AgentContext(desc=desc, state=state),
         NullCallbacks(),
         shorten_conversation_at_tokens=200_000,
         enable_user_feedback=True,

--- a/src/coding_assistant/agents/tests/test_run_loop_slices.py
+++ b/src/coding_assistant/agents/tests/test_run_loop_slices.py
@@ -12,7 +12,7 @@ from coding_assistant.agents.tests.helpers import (
     make_test_agent,
     make_ui_mock,
 )
-from coding_assistant.agents.types import AgentDescription, AgentState, AgentContext, TextResult, Tool
+from coding_assistant.agents.types import AgentDescription, AgentState, AgentContext, TextResult, Tool, AgentOutput
 from coding_assistant.tools.tools import FinishTaskTool, ShortenConversation
 
 
@@ -359,8 +359,7 @@ async def test_interrupt_feedback_injected_and_loop_continues(monkeypatch):
 @pytest.mark.asyncio
 async def test_errors_if_output_already_set():
     desc, state = make_test_agent(tools=[FinishTaskTool(), ShortenConversation()])
-    state.result = "r"
-    state.summary = "s"
+    state.output = AgentOutput(result="r", summary="s")
     with pytest.raises(RuntimeError, match="Agent already has a result or summary."):
         await run_agent_loop(
             AgentContext(desc=desc, state=state),

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -50,7 +50,7 @@ class Tool(ABC):
 
 
 # Immutable description of an agent
-@dataclass
+@dataclass(frozen=True)
 class AgentDescription:
     name: str
     model: str

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -49,12 +49,6 @@ class Tool(ABC):
     async def execute(self, parameters) -> ToolResult: ...
 
 
-@dataclass
-class AgentOutput:
-    result: str
-    summary: str
-
-
 # Immutable description of an agent
 @dataclass
 class AgentDescription:
@@ -68,7 +62,8 @@ class AgentDescription:
 @dataclass
 class AgentState:
     history: list = field(default_factory=list)
-    output: AgentOutput | None = None
+    result: str | None = None
+    summary: str | None = None
 
 
 class Completer(Protocol):

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -55,14 +55,18 @@ class AgentOutput:
     summary: str
 
 
+# Immutable description of an agent
 @dataclass
-class Agent:
+class AgentDescription:
     name: str
     model: str
-
     parameters: list[Parameter]
     tools: list[Tool]
 
+
+# Mutable state for an agent's execution
+@dataclass
+class AgentState:
     history: list = field(default_factory=list)
     output: AgentOutput | None = None
 

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -58,12 +58,18 @@ class AgentDescription:
     tools: list[Tool]
 
 
+# Final output of an agent run
+@dataclass
+class AgentOutput:
+    result: str
+    summary: str
+
+
 # Mutable state for an agent's execution
 @dataclass
 class AgentState:
     history: list = field(default_factory=list)
-    result: str | None = None
-    summary: str | None = None
+    output: AgentOutput | None = None
 
 
 # Combines the immutable description with the mutable state of an agent

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -60,7 +60,6 @@ class Agent:
     name: str
     model: str
 
-    description: str
     parameters: list[Parameter]
     tools: list[Tool]
 

--- a/src/coding_assistant/agents/types.py
+++ b/src/coding_assistant/agents/types.py
@@ -66,6 +66,13 @@ class AgentState:
     summary: str | None = None
 
 
+# Combines the immutable description with the mutable state of an agent
+@dataclass
+class AgentContext:
+    desc: AgentDescription
+    state: AgentState
+
+
 class Completer(Protocol):
     def __call__(
         self,

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -10,7 +10,6 @@ from coding_assistant.agents.execution import run_agent_loop
 from coding_assistant.agents.parameters import fill_parameters, Parameter
 from coding_assistant.agents.types import (
     AgentDescription,
-    AgentOutput,
     AgentState,
     FinishTaskResult,
     ShortenConversationResult,
@@ -91,7 +90,7 @@ class OrchestratorTool(Tool):
         state = AgentState(history=self._history or [])
 
         try:
-            output = await run_agent_loop(
+            output_state = await run_agent_loop(
                 desc,
                 state,
                 self._agent_callbacks,
@@ -102,8 +101,8 @@ class OrchestratorTool(Tool):
                 ui=self._ui,
                 is_interruptible=True,
             )
-            self.summary = output.summary
-            return TextResult(content=output.result)
+            self.summary = output_state.summary or ""
+            return TextResult(content=output_state.result or "")
         finally:
             self.history = state.history
 
@@ -171,8 +170,8 @@ class AgentTool(Tool):
             ],
         )
         state = AgentState()
-
-        output = await run_agent_loop(
+        
+        output_state = await run_agent_loop(
             desc,
             state,
             agent_callbacks=self._agent_callbacks,
@@ -184,7 +183,7 @@ class AgentTool(Tool):
             ui=self._ui,
         )
 
-        return TextResult(content=output.result)
+        return TextResult(content=output_state.result or "")
 
 
 class AskClientSchema(BaseModel):

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -102,8 +102,10 @@ class OrchestratorTool(Tool):
                 ui=self._ui,
                 is_interruptible=True,
             )
-            self.summary = output_state.summary or ""
-            return TextResult(content=output_state.result or "")
+            assert output_state.result is not None, "Agent did not produce a result"
+            assert output_state.summary is not None, "Agent did not produce a summary"
+            self.summary = output_state.summary
+            return TextResult(content=output_state.result)
         finally:
             self.history = state.history
 
@@ -146,7 +148,6 @@ class AgentTool(Tool):
         return self._config.model
 
     async def execute(self, parameters: dict) -> TextResult:
-        # Compose parameters with the tool description as a dedicated entry
         agent_params = [
             Parameter(
                 name="description",
@@ -171,8 +172,8 @@ class AgentTool(Tool):
             ],
         )
         state = AgentState()
-        
         ctx = AgentContext(desc=desc, state=state)
+
         output_state = await run_agent_loop(
             ctx,
             agent_callbacks=self._agent_callbacks,
@@ -183,8 +184,8 @@ class AgentTool(Tool):
             is_interruptible=False,
             ui=self._ui,
         )
-
-        return TextResult(content=output_state.result or "")
+    assert output_state.result is not None, "Agent did not produce a result"
+    return TextResult(content=output_state.result)
 
 
 class AskClientSchema(BaseModel):

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -66,7 +66,7 @@ class OrchestratorTool(Tool):
         orch_params = [
             Parameter(
                 name="description",
-                description="The description of your work and capabilities.",
+                description="The description of the agent's work and capabilities.",
                 value=self.description(),
             ),
             *fill_parameters(
@@ -92,7 +92,7 @@ class OrchestratorTool(Tool):
 
         try:
             ctx = AgentContext(desc=desc, state=state)
-            output = await run_agent_loop(
+            await run_agent_loop(
                 ctx,
                 self._agent_callbacks,
                 shorten_conversation_at_tokens=self._config.shorten_conversation_at_tokens,
@@ -102,8 +102,9 @@ class OrchestratorTool(Tool):
                 ui=self._ui,
                 is_interruptible=True,
             )
-            self.summary = output.summary
-            return TextResult(content=output.result)
+            assert state.output is not None, "Agent did not produce output"
+            self.summary = state.output.summary
+            return TextResult(content=state.output.result)
         finally:
             self.history = state.history
 
@@ -149,7 +150,7 @@ class AgentTool(Tool):
         agent_params = [
             Parameter(
                 name="description",
-                description="The description of your work and capabilities.",
+                description="The description of the agent's work and capabilities.",
                 value=self.description(),
             ),
             *fill_parameters(
@@ -172,7 +173,7 @@ class AgentTool(Tool):
         state = AgentState()
         ctx = AgentContext(desc=desc, state=state)
 
-        output = await run_agent_loop(
+        await run_agent_loop(
             ctx,
             agent_callbacks=self._agent_callbacks,
             shorten_conversation_at_tokens=self._config.shorten_conversation_at_tokens,
@@ -182,7 +183,8 @@ class AgentTool(Tool):
             is_interruptible=False,
             ui=self._ui,
         )
-        return TextResult(content=output.result)
+        assert state.output is not None, "Agent did not produce output"
+        return TextResult(content=state.output.result)
 
 
 class AskClientSchema(BaseModel):

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -63,7 +63,7 @@ class OrchestratorTool(Tool):
 
     async def execute(self, parameters: dict) -> TextResult:
         # Compose parameters with the tool description as a dedicated entry
-        orch_params = [
+        params = [
             Parameter(
                 name="description",
                 description="The description of the agent's work and capabilities.",
@@ -78,7 +78,7 @@ class OrchestratorTool(Tool):
         desc = AgentDescription(
             name="Orchestrator",
             model=self._config.expert_model,
-            parameters=orch_params,
+            parameters=params,
             tools=[
                 FinishTaskTool(),
                 ShortenConversation(),
@@ -147,7 +147,7 @@ class AgentTool(Tool):
         return self._config.model
 
     async def execute(self, parameters: dict) -> TextResult:
-        agent_params = [
+        params = [
             Parameter(
                 name="description",
                 description="The description of the agent's work and capabilities.",
@@ -162,7 +162,7 @@ class AgentTool(Tool):
         desc = AgentDescription(
             name="Agent",
             model=self.get_model(parameters),
-            parameters=agent_params,
+            parameters=params,
             tools=[
                 FinishTaskTool(),
                 ShortenConversation(),

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -296,7 +296,7 @@ class FinishTaskSchema(BaseModel):
         description="The result of the work on the task. The work of the agent is evaluated based on this result."
     )
     summary: str = Field(
-        description="A concise summary of the conversation the agent and the client had. There should be enough context such that the work could be continued based on this summary. It should be possible to evaluate your result using only your input parameters and this summary. That means that you need to include all of the user feedback you worked into your result.",
+        description="A concise summary of the conversation the agent and the client had. The summary should be a single paragraph. There should be enough context such that the work could be continued based on this summary. It should be possible to evaluate your result using only your input parameters and this summary. That means that you need to include all of the user feedback you worked into your result.",
     )
 
 

--- a/src/coding_assistant/tools/tools.py
+++ b/src/coding_assistant/tools/tools.py
@@ -11,6 +11,7 @@ from coding_assistant.agents.parameters import fill_parameters, Parameter
 from coding_assistant.agents.types import (
     AgentDescription,
     AgentState,
+    AgentContext,
     FinishTaskResult,
     ShortenConversationResult,
     TextResult,
@@ -90,9 +91,9 @@ class OrchestratorTool(Tool):
         state = AgentState(history=self._history or [])
 
         try:
+            ctx = AgentContext(desc=desc, state=state)
             output_state = await run_agent_loop(
-                desc,
-                state,
+                ctx,
                 self._agent_callbacks,
                 shorten_conversation_at_tokens=self._config.shorten_conversation_at_tokens,
                 tool_confirmation_patterns=self._config.tool_confirmation_patterns,
@@ -171,9 +172,9 @@ class AgentTool(Tool):
         )
         state = AgentState()
         
+        ctx = AgentContext(desc=desc, state=state)
         output_state = await run_agent_loop(
-            desc,
-            state,
+            ctx,
             agent_callbacks=self._agent_callbacks,
             shorten_conversation_at_tokens=self._config.shorten_conversation_at_tokens,
             tool_confirmation_patterns=self._config.tool_confirmation_patterns,


### PR DESCRIPTION
Summary

Split the Agent into an immutable description and a mutable state to make flows safer and testing clearer. Introduce AgentContext to pass both together. The agent loop now mutates state and no longer returns an AgentOutput; callers should read from state.output.

What changed
- Types
  - Add AgentDescription (frozen), AgentState (mutable), and AgentContext.
  - Keep AgentOutput for final result; state.output holds this when finished.
- Execution
  - run_agent_loop(ctx, ...) mutates ctx.state and does not return; set span attributes for result/summary.
  - do_single_step/handle_tool_call(s) accept AgentContext.
  - Start message built from desc.parameters; remove description from types.
  - Validate missing tool function name; remove default '{}' for tool-call args to surface JSON errors.
  - Telemetry: record function.args/result and agent.history/result/summary.
- Tools
  - OrchestratorTool/AgentTool build AgentDescription+AgentState; pass description as a Parameter.
  - Assert state.output before returning; wire history from state.
- Tests
  - Update helpers and tests to use desc/state/context and new API across execution, shorten flow, model contract, and run loop slices.
  - Adjust assertions to read from state.history/output.

Motivation
- Enforce immutability where appropriate and isolate mutable runtime state.
- Make state transitions explicit and easier to reason about and test.
- Stricter tool-call arg handling prevents silent '{}' fallbacks and surfaces malformed JSON earlier.

Migration notes
- Callers of run_agent_loop should not expect a return value; read result from ctx.state.output instead.
- When constructing agents programmatically, provide description via a Parameter named "description" as shown in Tools.

Testing
- just test: 84/84 pass locally (pytest -n auto), with the known non-blocking PytestUnraisableExceptionWarning during teardown.

Follow-ups
- Optional: add TYPE_CHECKING-only typing for tool_call/message and consider a broader typing cleanup.
